### PR TITLE
Update:

### DIFF
--- a/NEQ_CONTOUR.f90
+++ b/NEQ_CONTOUR.f90
@@ -94,8 +94,8 @@ contains
     params%t       = linspace(0d0,tmax_,Ntime,mesh=dt_)
     params%tau(0:) = linspace(0d0,beta,Ntau+1,mesh=dtau_)
     params%wm      = pi/beta*(2*arange(1,Niw)-1)
-    !if(dt_/=params%dt)stop "neq_contour/set_kb_contour_params: dt != dt_ "
-    !if(dtau_/=params%dtau)stop "neq_contour/set_kb_contour_params: dtau != dtau_ "
+    if(dt_/=params%dt)stop "neq_contour/set_kb_contour_params: dt != dt_ "
+    if(dtau_/=params%dtau)stop "neq_contour/set_kb_contour_params: dtau != dtau_ "
     call print_kb_contour_params(params)
     call write_kb_contour_params(params,"contour_info.neqipt")
   end subroutine setup_kb_contour_params

--- a/NEQ_CONTOUR_GF.f90
+++ b/NEQ_CONTOUR_GF.f90
@@ -2,12 +2,11 @@ MODULE NEQ_CONTOUR_GF
   USE NEQ_CONTOUR
   USE SF_CONSTANTS, only: one,xi,zero,pi
   USE SF_IOTOOLS
-  !USE SF_SPECIAL
   implicit none
   private
 
+
   ! KADANOFF-BAYM CONTOUR GREEN'S FUNCTIONS:
-  !====================================================
   type,public :: kb_contour_gf
      complex(8),dimension(:,:),allocatable :: less
      complex(8),dimension(:,:),allocatable :: ret
@@ -15,66 +14,75 @@ MODULE NEQ_CONTOUR_GF
      real(8),dimension(:),allocatable      :: mats
      complex(8),dimension(:),allocatable   :: iw
      logical                               :: status=.false.
-     logical                               :: anomalous=.false.
-     integer                               :: N=0
-     integer                               :: L=0
-     integer                               :: LF=0
   end type kb_contour_gf
   !
-  type,public :: kb_contour_sigma
-     type(kb_contour_gf)                   :: self
-     complex(8),dimension(:),allocatable   :: hfb
+  !
+  !
+  ! KADANOFF-BAYM CONTOUR SIGMA FUNCTION:
+  type,public                              :: kb_contour_sigma
+     type(kb_contour_gf)                   :: reg
+     complex(8),dimension(:),allocatable   :: hf
+     logical                               :: status=.false.
   end type kb_contour_sigma
   !
   !
-  !
+  !  
   ! KADANOFF-BAYM CONTOUR GREEN'S FUNCTIONS DERIVATIVE
-  !====================================================
-  type,public :: kb_contour_dgf
-     complex(8),dimension(:),allocatable :: less,gtr
-     complex(8),dimension(:),allocatable :: ret
-     complex(8),dimension(:),allocatable :: lmix
-     logical                             :: status=.false.
-     logical                             :: anomalous=.false.
-     integer                             :: N=0
-     integer                             :: L=0
+  type,public                              :: kb_contour_dgf
+     complex(8),dimension(:),allocatable   :: less,gtr
+     complex(8),dimension(:),allocatable   :: ret
+     complex(8),dimension(:),allocatable   :: lmix
+     logical                               :: status=.false.
+     logical                               :: anomalous=.false.
   end type kb_contour_dgf
   !
   !
   !
-  !
-  !ALLOCATION ROUTINES:
+  ! ALLOCATION/DEALLOCATION ROUTINES:
   interface allocate_kb_contour_gf
      module procedure allocate_kb_contour_gf_main
-     module procedure allocate_kb_contour_gf_nambu_redux
-     module procedure allocate_kb_contour_gf_nambu
   end interface allocate_kb_contour_gf
+  interface deallocate_kb_contour_gf
+     module procedure deallocate_kb_contour_gf_main
+  end interface deallocate_kb_contour_gf
+  public :: allocate_kb_contour_gf
+  public :: deallocate_kb_contour_gf
+  !
+  interface allocate_kb_contour_sigma
+     module procedure allocate_kb_contour_sigma_main
+  end interface allocate_kb_contour_sigma
+  interface deallocate_kb_contour_sigma
+     module procedure deallocate_kb_contour_sigma_main
+  end interface deallocate_kb_contour_sigma
+  public :: allocate_kb_contour_sigma
+  public :: deallocate_kb_contour_sigma
   !
   interface allocate_kb_contour_dgf
      module procedure allocate_kb_contour_dgf_main
-     module procedure allocate_kb_contour_dgf_nambu_redux
   end interface allocate_kb_contour_dgf
-  !
-  public :: allocate_kb_contour_gf
+  interface deallocate_kb_contour_dgf
+     module procedure deallocate_kb_contour_dgf_main
+  end interface deallocate_kb_contour_dgf
   public :: allocate_kb_contour_dgf
-  !
-  !
-  !DEALLOCATION ROUTINES:
-  public :: deallocate_kb_contour_gf
   public :: deallocate_kb_contour_dgf
   !
   !
-  !CHECK DIMENSIONS:
-  interface check_dimension_kb_contour
-     module procedure check_dimension_kb_contour_gf
-     module procedure check_dimension_kb_contour_gf_
-     module procedure check_dimension_kb_contour_dgf
-     module procedure check_dimension_kb_contour_dgf_
-  end interface check_dimension_kb_contour
-  public :: check_dimension_kb_contour
+  !VIE/VIDE SOLVER:
+  interface vie_kb_contour_gf
+     module procedure vie_kb_contour_gf_Q
+     module procedure vie_kb_contour_gf_Sigma
+     module procedure vie_kb_contour_gf_Delta
+  end interface vie_kb_contour_gf
+  public :: vie_kb_contour_gf
+  !
+  interface vide_kb_contour_gf
+     module procedure vide_kb_contour_gf_K
+     module procedure vide_kb_contour_gf_Sigma
+  end interface vide_kb_contour_gf
+  public :: vide_kb_contour_gf
   !
   !
-  !ADD (TOTAL DOMAIN) ROUTINES:
+  ! ADD (TOTAL DOMAIN) ROUTINES:
   interface add_kb_contour_gf
      module procedure add_kb_contour_gf_simple
      module procedure add_kb_contour_gf_recursive
@@ -82,9 +90,10 @@ MODULE NEQ_CONTOUR_GF
      module procedure add_kb_contour_gf_delta_c
   end interface add_kb_contour_gf
   public :: add_kb_contour_gf
+  public :: add_kb_contour_dgf
   !
   !
-  !SUM (PERIMETER) ROUTINES:
+  ! SUM (PERIMETER) ROUTINES:
   interface sum_kb_contour_gf
      module procedure sum_kb_contour_gf_simple
      module procedure sum_kb_contour_gf_delta_d
@@ -94,54 +103,50 @@ MODULE NEQ_CONTOUR_GF
   public :: sum_kb_contour_gf
   !
   !
-  !DELETE (RESET PERIMETER) ROUTINES:
+  ! DELETE (RESET PERIMETER) ROUTINES:
   public :: del_kb_contour_gf
   !
-  !CONVOLUTION:
+  !
+  ! CONVOLUTION:
   interface convolute_kb_contour_gf
-     module procedure convolute_kb_contour_gf_simple
-     module procedure convolute_kb_contour_gf_recursive
-     module procedure convolute_kb_contour_gf_delta
+     module procedure convolute_kb_contour_gf_gf
+     module procedure convolute_kb_contour_sigma_gf
+     module procedure convolute_kb_contour_gf_sigma
+     module procedure convolute_kb_contour_gf_gf_recursive
+     module procedure convolute_kb_contour_gf_sigma_recursive
+     ! module procedure convolute_kb_contour_gf_delta_recursive
+     module procedure convolute_kb_contour_gf_delta_left
+     module procedure convolute_kb_contour_gf_delta_right
   end interface convolute_kb_contour_gf
   public :: convolute_kb_contour_gf
   !
   !
-  !OTHER ROUTINES && PLOT:
+  ! OTHER ROUTINES && PLOT:  
   public :: extrapolate_kb_contour_gf
   public :: save_kb_contour_gf
   public :: inquire_kb_contour_gf
   public :: read_kb_contour_gf
   public :: plot_kb_contour_gf
-  !
-  !
-  !INTEGRATION ROUTINES:
-  interface kb_trapz
-     module procedure kb_trapz_d
-     module procedure kb_trapz_c
-  end interface kb_trapz
-  !
-  interface kb_half_trapz
-     module procedure kb_half_trapz_d
-     module procedure kb_half_trapz_c
-  end interface kb_half_trapz
-  !
-  public :: kb_trapz,kb_half_trapz
-  !
-  !
-  !VIE/VIDE SOLVER:
-  interface vie_kb_contour_gf
-     module procedure vie_kb_contour_gf_q
-     module procedure vie_kb_contour_gf_delta
-  end interface vie_kb_contour_gf
-  public :: vie_kb_contour_gf
-  public :: vide_kb_contour_gf
+  public :: extrapolate_kb_contour_sigma
+  public :: save_kb_contour_sigma
+  public :: inquire_kb_contour_sigma
+  public :: read_kb_contour_sigma
+  public :: plot_kb_contour_sigma
+  interface check_dimension_kb_contour
+     module procedure check_dimension_kb_contour_gf
+     module procedure check_dimension_kb_contour_gf_
+     module procedure check_dimension_kb_contour_sigma
+     module procedure check_dimension_kb_contour_sigma_
+     module procedure check_dimension_kb_contour_dgf
+     module procedure check_dimension_kb_contour_dgf_
+  end interface check_dimension_kb_contour
+  public :: check_dimension_kb_contour
   !
   ! 
   !SYMMETRIES & COMPONENTS:
   public :: get_gtr
   public :: get_adv
   public :: get_rmix
-  public :: get_bar
   !
   !
   !OVERLOAD OPERATORS
@@ -155,1430 +160,89 @@ MODULE NEQ_CONTOUR_GF
      module procedure kb_contour_dgf_scalarR_d
      module procedure kb_contour_dgf_scalarR_c
   end interface operator(*)
-  !
   interface assignment(=)
      module procedure kb_contour_gf_equality_
      module procedure kb_contour_dgf_equality_
      module procedure kb_contour_gf_equality__
      module procedure kb_contour_dgf_equality__
   end interface assignment(=)
-  !
-  !
   public :: operator(*)
   public :: assignment(=)
+  !
+  !
+  !INTEGRATION ROUTINES:
+  interface kb_trapz
+     module procedure kb_trapz_d
+     module procedure kb_trapz_c
+  end interface kb_trapz
+  public :: kb_trapz
+  !
+  interface kb_half_trapz
+     module procedure kb_half_trapz_d
+     module procedure kb_half_trapz_c
+  end interface kb_half_trapz
+  public :: kb_half_trapz
 
 
 
 contains
 
 
+  !======= ALLOCATE/DEALLOCATE ======= 
+  include "neq_contour_gf_allocate.f90"
 
-  !======= ALLOCATE ======= 
-  subroutine allocate_kb_contour_gf_main(G,params)
-    type(kb_contour_gf)     :: G
-    type(kb_contour_params) :: params
-    integer                 :: i,j,N,L,Lf
-    if(allocated(G%less))deallocate(G%less)
-    if(allocated(G%ret)) deallocate(G%ret)
-    if(allocated(G%lmix))deallocate(G%lmix)
-    if(allocated(G%mats))deallocate(G%mats)
-    N = params%Ntime            !<== allocate at maximum time
-    L = params%Ntau
-    Lf= params%Niw
-    G%N = N
-    G%L = L
-    G%Lf= Lf
-    allocate(G%less(N,N))  ; G%less=zero
-    allocate(G%ret(N,N))   ; G%ret=zero
-    allocate(G%lmix(N,0:L)); G%lmix=zero
-    allocate(G%mats(0:L))  ; G%mats=0d0
-    allocate(G%iw(Lf))     ; G%iw=zero
-    G%status=.true.
-  end subroutine allocate_kb_contour_gf_main
-  !
-  subroutine allocate_kb_contour_gf_nambu_redux(G,params)
-    type(kb_contour_gf),dimension(2) :: G
-    type(kb_contour_params)          :: params
-    call allocate_kb_contour_gf_main(G(1),params)
-    call allocate_kb_contour_gf_main(G(2),params)
-    G(1)%anomalous=.false.
-    G(2)%anomalous=.true.
-  end subroutine allocate_kb_contour_gf_nambu_redux
-  !
-  subroutine allocate_kb_contour_gf_nambu(G,params)
-    type(kb_contour_gf),dimension(2,2) :: G
-    type(kb_contour_params)            :: params
-    integer                            :: i,j
-    do i=1,2
-       do j=1,2
-          call allocate_kb_contour_gf_main(G(i,j),params)
-       enddo
-    enddo
-    G(1,1)%anomalous=.false.
-    G(1,2)%anomalous=.true.
-    G(2,1)%anomalous=.true.
-    G(2,2)%anomalous=.false.
-  end subroutine allocate_kb_contour_gf_nambu
-  !
-  !
-  subroutine allocate_kb_contour_dgf_main(dG,params,wgtr)
-    type(kb_contour_dgf)    :: dG
-    type(kb_contour_params) :: params
-    integer                 :: i,j,N,L
-    logical,optional        :: wgtr
-    if(allocated(dG%less))deallocate(dG%less)
-    if(allocated(dG%ret)) deallocate(dG%ret)
-    if(allocated(dG%lmix))deallocate(dG%lmix)
-    N=params%Ntime           !<== allocate at maximum time
-    L=params%Ntau
-    dG%N=N
-    dG%L=L
-    allocate(dG%less(N))  ; dG%less=zero
-    allocate(dG%ret(N))   ; dG%ret=zero
-    allocate(dG%lmix(0:L)); dG%lmix=zero
-    if(present(wgtr).AND.wgtr)then
-       allocate(dG%gtr(N))
-       dG%gtr=zero
-    endif
-    dG%status=.true.
-  end subroutine allocate_kb_contour_dgf_main
-  !
-  subroutine allocate_kb_contour_dgf_nambu_redux(dG,params)
-    type(kb_contour_dgf),dimension(2)     :: dG
-    type(kb_contour_params) :: params
-    call allocate_kb_contour_dgf_main(dG(1),params)
-    call allocate_kb_contour_dgf_main(dG(2),params)
-    dG(1)%anomalous=.false.
-    dG(2)%anomalous=.true.
-  end subroutine allocate_kb_contour_dgf_nambu_redux
 
 
+  !======= ADD =======
+  !C(t,t')=A(t,t') + B(t,t'), with t,t'=0,t_max
+  include "neq_contour_gf_add.f90"
 
 
 
-
-
-
-
-  !======= DEALLOCATE ======= 
-  subroutine deallocate_kb_contour_gf(G)
-    type(kb_contour_gf) :: G
-    if(.not.G%status)stop "contour_gf/deallocate_kb_contour_gf: G not allocated"
-    deallocate(G%less,G%ret,G%lmix,G%mats,G%iw)
-    G%N=0
-    G%L=0
-    G%Lf=0
-    G%status=.false.
-  end subroutine deallocate_kb_contour_gf
-  !
-  subroutine deallocate_kb_contour_dgf(dG)
-    type(kb_contour_dgf) :: dG
-    if(.not.dG%status)stop "contour_gf/deallocate_kb_contour_dgf: dG not allocated"
-    deallocate(dG%less,dG%ret,dG%lmix)
-    if(allocated(dG%gtr))deallocate(dG%gtr)
-    dG%N=0
-    dG%L=0
-    dG%status=.false.
-  end subroutine deallocate_kb_contour_dgf
-
-
-
-
-
-
-  !======= CHECK DIMENSION ======= 
-  function check_dimension_kb_contour_gf(G,params) result(bool)
-    type(kb_contour_gf)     :: G
-    type(kb_contour_params) :: params
-    logical                 :: bool
-    integer                 :: N,L
-    bool=.false.
-    N=params%Ntime              !<== check size at maximum time
-    L=params%Ntau
-    if( (size(G%less)/=N**2) .OR. (size(G%ret)/=N**2) )&
-         stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions less/ret"
-    if( size(G%lmix)/=N*(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions lmix"
-    if( size(G%mats)/=(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions mats"
-    bool=.true.
-  end function check_dimension_kb_contour_gf
-  !
-  function check_dimension_kb_contour_gf_(G,N,L) result(bool)
-    type(kb_contour_gf)     :: G
-    logical                 :: bool
-    integer                 :: N,L
-    bool=.false.
-    if( (size(G%less)/=N**2) .OR. (size(G%ret)/=N**2) )&
-         stop "ERROR contour_gf/check_dimension_kb_contour_gf: wrong dimensions less/ret"
-    if( size(G%lmix)/=N*(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions lmix"
-    if( size(G%mats)/=(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions mats"
-    bool=.true.
-  end function check_dimension_kb_contour_gf_
-  !
-  function check_dimension_kb_contour_dgf(dG,params) result(bool)
-    type(kb_contour_dgf)    :: dG
-    type(kb_contour_params) :: params
-    logical                 :: bool
-    integer                 :: N,L
-    bool=.false.
-    N=params%Ntime              !<== check size at maximum time
-    L=params%Ntau
-    if( (size(dG%less)/=N) .OR. (size(dG%ret)/=N) )&
-         stop "ERROR contour_gf/check_dimension_kb_contour_dgf: wrong dimensions less/ret"
-    if( size(dG%lmix)/=(L+1) )&
-         stop "ERROR contour_gf/check_dimension_kb_contour_dgf: wrong dimensions lmix"
-    bool=.true.
-  end function check_dimension_kb_contour_dgf
-  !
-  function check_dimension_kb_contour_dgf_(dG,N,L) result(bool)
-    type(kb_contour_dgf)    :: dG
-    logical                 :: bool
-    integer                 :: N,L
-    bool=.false.
-    if( (size(dG%less)/=N) .OR. (size(dG%ret)/=N) )&
-         stop "ERROR contour_gf/check_dimension_kb_contour_dgf: wrong dimensions less/ret"
-    if( size(dG%lmix)/=(L+1) )&
-         stop "ERROR contour_gf/check_dimension_kb_contour_dgf: wrong dimensions lmix"
-    bool=.true.
-  end function check_dimension_kb_contour_dgf_
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  !======= SAVE ======= 
-  subroutine save_kb_contour_gf(G,file)
-    type(kb_contour_gf) :: G
-    character(len=*)    :: file
-    integer             :: unit
-    if(.not.G%status)stop "contour_gf/save_kb_contour_gf: G not allocated"
-    unit = free_unit()
-    open(unit,file=reg(file)//"_dimension.data.neqipt")
-    write(unit,"(A1,3A4,3X)")"#","N","L","Lf"
-    write(unit,"(1X,3I4,3X)")G%N,G%L,G%Lf
-    close(unit)
-    call store_data(reg(file)//"_less.data.neqipt",G%less(:,:))
-    call store_data(reg(file)//"_ret.data.neqipt", G%ret(:,:))
-    call store_data(reg(file)//"_lmix.data.neqipt",G%lmix(:,0:))
-    call store_data(reg(file)//"_mats.data.neqipt",G%mats(0:))
-    call store_data(reg(file)//"_iw.data.neqipt",G%iw(:))
-  end subroutine save_kb_contour_gf
-  !
-  subroutine save_kb_contour_dgf(dG,file)
-    type(kb_contour_dgf)  :: dG
-    character(len=*)      :: file
-    integer :: unit
-    if(.not.dG%status)stop "contour_gf/save_kb_contour_dgf: dG not allocated"
-    unit = free_unit()
-    open(unit,file=reg(file)//"_dimension.data.neqipt")
-    write(unit,"(A1,2A4,2X)")"#","N","L"
-    write(unit,"(1X,2I4,2X)")dG%N,dG%L
-    close(unit)
-    call store_data(reg(file)//"_less.data.neqipt",dG%less(:))
-    call store_data(reg(file)//"_ret.data.neqipt", dG%ret(:))
-    call store_data(reg(file)//"_lmix.data.neqipt",dG%lmix(0:))
-  end subroutine save_kb_contour_dgf
-
-
-
-
-
-
-
-
-
-  !======= READ ======= 
-  subroutine read_kb_contour_gf(G,file)
-    type(kb_contour_gf)  :: G
-    character(len=*)     :: file
-    logical              :: check
-    check = inquire_kb_contour_gf(file)
-    if(.not.G%status.OR..not.check)stop "contour_gf/read_kb_contour_gf: G not allocated"
-    call read_data(trim(file)//"_less.data.neqipt",G%less(:,:))
-    call read_data(trim(file)//"_ret.data.neqipt",G%ret(:,:))
-    call read_data(trim(file)//"_lmix.data.neqipt",G%lmix(:,0:))
-    call read_data(trim(file)//"_mats.data.neqipt",G%mats(0:))
-    call read_data(trim(file)//"_iw.data.neqipt",G%iw(:))
-  end subroutine read_kb_contour_gf
-  !
-  subroutine read_kb_contour_dgf(dG,file)
-    type(kb_contour_dgf) :: dG
-    character(len=*)     :: file
-    logical              :: check
-    check = inquire_kb_contour_dgf(file)
-    if(.not.dG%status.OR..not.check)stop "contour_gf/read_kb_contour_dgf: dG not allocated"
-    call read_data(trim(file)//"_less.data.neqipt",dG%less(:))
-    call read_data(trim(file)//"_ret.data.neqipt",dG%ret(:))
-    call read_data(trim(file)//"_lmix.data.neqipt",dG%lmix(0:))
-  end subroutine read_kb_contour_dgf
-  !
-  function inquire_kb_contour_gf(file) result(check)
-    integer          :: i
-    logical          :: check,bool(5)
-    character(len=*) :: file
-    character(len=16),dimension(5)  :: ctype=([ character(len=5) :: 'less','ret','lmix','mats','iw'])
-    check=.true.
-    do i=1,5
-       inquire(file=reg(file)//"_"//reg(ctype(i))//".data.neqipt",exist=bool(i))
-       if(.not.bool(i))inquire(file=reg(file)//"_"//reg(ctype(i))//".data.neqipt.gz",exist=bool(i))
-       check=check.AND.bool(i)
-    enddo
-  end function inquire_kb_contour_gf
-  !
-  function inquire_kb_contour_dgf(file) result(check)
-    integer          :: i
-    logical          :: check,bool(3)
-    character(len=*) :: file
-    character(len=16),dimension(3)  :: ctype=([character(len=5) :: 'less','ret','lmix'])
-    check=.true.
-    do i=1,3
-       inquire(file=reg(file)//"_"//reg(ctype(i))//".data.neqipt",exist=bool(i))
-       if(.not.bool(i))inquire(file=reg(file)//"_"//reg(ctype(i))//".data.neqipt.gz",exist=bool(i))
-       check=check.AND.bool(i)
-    enddo
-  end function inquire_kb_contour_dgf
-
-
-
-
-
-
-
-
-
-
-  !======= PLOT ======= 
-  subroutine plot_kb_contour_gf(file,G,params)
-    character(len=*)        :: file
-    type(kb_contour_gf)     :: G
-    type(kb_contour_params) :: params
-    integer                 :: Nt,i
-    if(.not.G%status)stop "contour_gf/plot_kb_contour_gf: G is not allocated" 
-    Nt=params%Ntime
-    call splot3d(reg(file)//"_less_t_t.data.neqipt",params%t(:Nt),params%t(:Nt),G%less(:Nt,:Nt))
-    call splot3d(reg(file)//"_ret_t_t.data.neqipt",params%t(:Nt),params%t(:Nt),G%ret(:Nt,:Nt))
-    call splot3d(reg(file)//"_lmix_t_tau.data.neqipt",params%t(:Nt),params%tau(0:),G%lmix(:Nt,0:))
-    call splot(reg(file)//"_mats_tau.data.neqipt",params%tau(0:),G%mats(0:))
-    call splot(reg(file)//"_tau_tau.data.neqipt",(/(i*params%beta/params%Niw,i=0,params%Niw)/),G%mats(0:))
-    call splot(reg(file)//"_mats_iw.data.neqipt",params%wm(:),G%iw(:))
-  end subroutine plot_kb_contour_gf
-  !
-  subroutine plot_kb_contour_dgf(file,dG,params)
-    character(len=*)        :: file
-    type(kb_contour_dgf)    :: dG
-    type(kb_contour_params) :: params
-    integer                 :: Nt
-    if(.not.dG%status)stop "contour_gf/plot_kb_contour_gf: G is not allocated" 
-    Nt=params%Ntime
-    call splot(reg(file)//"_less_t.data.neqipt",params%t(:Nt),dG%less(:Nt))
-    call splot(reg(file)//"_ret_t.data.neqipt",params%t(:Nt),dG%ret(:Nt))
-    call splot(reg(file)//"_lmix_tau.data.neqipt",params%tau(0:),dG%lmix(0:))
-  end subroutine plot_kb_contour_dgf
-
-
-
-
-
-
-  !======= ADD ======= 
-  !C(t,t')=A(t,t') + B(t,t'), with t=t_max && t'=0,t_max
-  !t_max_index==N
-  subroutine add_kb_contour_gf_simple(A,B,C,params)
-    type(kb_contour_gf)     :: A,B,C
-    type(kb_contour_params) :: params
-    integer                 :: N,L
-    logical                 :: checkA,checkB,checkC
-    if(  (.not.A%status).OR.&
-         (.not.B%status).OR.&
-         (.not.C%status))stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
-    N   = params%Ntime   !<== work with the TOTAL size of the contour
-    L   = params%Ntau
-    !
-    checkA=check_dimension_kb_contour(A,N,L) 
-    checkB=check_dimension_kb_contour(B,N,L)
-    checkC=check_dimension_kb_contour(C,N,L)
-    !
-    C%less(:,:) = A%less(:,:) + B%less(:,:)
-    C%ret(:,:)  = A%ret(:,:)  + B%ret(:,:)
-    C%lmix(:,0:)= A%lmix(:,0:)+ B%lmix(:,0:)
-    C%mats(0:)  = A%mats(0:)  + B%mats(0:)
-    C%iw(:)    = A%iw(:)    + B%iw(:)
-  end subroutine  add_kb_contour_gf_simple
-
-  subroutine add_kb_contour_gf_recursive(A,C,params)
-    type(kb_contour_gf)     :: A(:)
-    type(kb_contour_gf)     :: C
-    type(kb_contour_params) :: params
-    integer                 :: i,Na,N,L
-    logical                 :: checkA,checkC
-    !
-    Na=size(A)
-    do i=1,Na
-       if(  (.not.A(i)%status) )stop "contour_gf/add_kb_contour_gf: A(i) not allocated"
-    enddo
-    if(  (.not.C%status) )stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
-    N   = params%Ntime    !<== work with the TOTAL size of the contour
-    L   = params%Ntau
-    !
-    do i=1,Na
-       checkA=check_dimension_kb_contour(A(i),N,L) 
-    enddo
-    checkC=check_dimension_kb_contour(C,N,L)
-    !
-    C=zero
-    do i=1,Na
-       C%less(:,:) = C%less(:,:) + A(i)%less(:,:)
-       C%ret(:,:)  = C%ret(:,:)  + A(i)%ret(:,:)
-       C%lmix(:,0:)= C%lmix(:,0:)+ A(i)%lmix(:,0:)
-       C%mats(0:)  = C%mats(0:)  + A(i)%mats(0:)
-       C%iw(:)     = C%iw(:)    + A(i)%iw(:)
-    enddo
-  end subroutine  add_kb_contour_gf_recursive
-
-  subroutine add_kb_contour_dgf(A,B,C,params)
-    type(kb_contour_dgf)    :: A,B,C
-    type(kb_contour_params) :: params
-    integer                 :: N,L
-    logical                 :: checkA,checkB,checkC
-    if(  (.not.A%status).OR.&
-         (.not.B%status).OR.&
-         (.not.C%status))stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
-    N   = params%Nt                 !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    !
-    checkA=check_dimension_kb_contour(A,N,L)
-    checkB=check_dimension_kb_contour(B,N,L)
-    checkC=check_dimension_kb_contour(C,N,L)
-    C%less(:) = A%less(:) + B%less(:)
-    C%ret(:)  = A%ret(:)  + B%ret(:)  
-    C%lmix(0:)= A%lmix(0:)+ B%lmix(0:)
-  end subroutine add_kb_contour_dgf
-
-  subroutine add_kb_contour_gf_delta_d(A,B,C,params)
-    type(kb_contour_gf)     :: A,C
-    real(8),dimension(:)    :: B
-    type(kb_contour_params) :: params
-    integer                 :: N,L,i
-    logical                 :: checkA,checkC
-    if(  (.not.A%status).OR.&
-         (.not.C%status))stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
-    N   = params%Ntime
-    L   = params%Ntau
-    !
-    checkA=check_dimension_kb_contour(A,N,L) 
-    checkC=check_dimension_kb_contour(C,N,L)
-    if(size(B)<N)stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
-    C%less(:,:) = A%less(:,:)
-    C%ret(:,:)  = A%ret(:,:)
-    C%lmix(:,0:)= A%lmix(:,0:)
-    C%mats(0:)  = A%mats(0:)
-    C%iw(:)     = A%iw(:) + B(1)
-    !
-    do i=1,N
-       C%ret(i,i) = C%ret(i,i) + B(i)
-    enddo
-    C%mats(0) = C%mats(0) + B(1)
-  end subroutine  add_kb_contour_gf_delta_d
-
-  subroutine add_kb_contour_gf_delta_c(A,B,C,params)
-    type(kb_contour_gf)     :: A,C
-    complex(8),dimension(:) :: B
-    type(kb_contour_params) :: params
-    integer                 :: N,L,i
-    logical                 :: checkA,checkC
-    if(  (.not.A%status).OR.&
-         (.not.C%status))stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
-    N   = params%Ntime
-    L   = params%Ntau
-    !
-    checkA=check_dimension_kb_contour(A,N,L) 
-    checkC=check_dimension_kb_contour(C,N,L)
-    if(size(B)<N)stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
-    C%less(:,:) = A%less(:,:)
-    C%ret(:,:)  = A%ret(:,:)
-    C%lmix(:,0:)= A%lmix(:,0:)
-    C%mats(0:)  = A%mats(0:)
-    C%iw(:)     = A%iw(:) + B(1)
-    !
-    do i=1,N
-       C%ret(i,i) = C%ret(i,i) + B(i)
-    enddo
-    C%mats(0) = C%mats(0) + B(1)
-  end subroutine  add_kb_contour_gf_delta_c
-
-
-
-
-
-
-
-
-
-
-
-  !======= SUM ======= 
-  ! performs the sum a*A + b*B and stores it in C along the perimeter
-  ! can be called multiple times to add up. 
-  subroutine sum_kb_contour_gf_simple(A,ak,B,bk,C,params)
-    type(kb_contour_gf)               :: A,B
-    type(kb_contour_gf),intent(inout) :: C
-    real(8)                           :: ak,bk
-    type(kb_contour_params)           :: params
-    integer                           :: N,L
-    if(  (.not.A%status).OR.&
-         (.not.B%status).OR.&
-         (.not.C%status))stop "contour_gf/addup_kb_contour_gf: G or Gk not allocated"
-    !
-    N   = params%Nt   !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    !
-    if(N==1)then
-       C%mats(0:) = ak*A%mats(0:) + bk*B%mats(0:)
-       C%iw(:)    = ak*A%iw(:)    + bk*B%iw(:)
-    endif
-    !
-    C%ret(N,1:N)   = ak*A%ret(N,1:N)   + bk*B%ret(N,1:N)
-    C%less(N,1:N)  = ak*A%less(N,1:N)  + bk*B%less(N,1:N)
-    C%lmix(N,0:)   = ak*A%lmix(N,0:)   + bk*B%lmix(N,0:)
-    !
-    if(.not.C%anomalous)then
-       C%less(1:N-1,N)= -conjg(C%less(N,1:N-1))
-    else
-       C%less(1:N-1,N)= C%less(N,1:N-1)+C%ret(N,1:N-1)
-    endif
-    !
-  end subroutine sum_kb_contour_gf_simple
-
-  subroutine sum_kb_contour_gf_delta_d(A,ak,B,bk,C,params)
-    type(kb_contour_gf)               :: A
-    real(8),dimension(:)              :: B
-    type(kb_contour_gf),intent(inout) :: C
-    real(8)                           :: ak,bk
-    type(kb_contour_params)           :: params
-    integer                           :: N,L
-    if(  (.not.A%status).OR.&
-         (.not.C%status))stop "contour_gf/addup_kb_contour_gf: G or Gk not allocated"
-    !
-    N   = params%Nt   !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    !
-    call del_kb_contour_gf(C,params)
-    !
-    if(N==1)then 
-       C%mats(0)  = ak*A%mats(0)  + B(1)
-       C%mats(1:) = ak*A%mats(1:)
-       C%iw(:)    = ak*A%iw(:)    + B(1)
-    endif
-    !
-    C%ret(N,1:N)   = ak*A%ret(N,1:N)
-    C%less(N,1:N)  = ak*A%less(N,1:N)
-    C%lmix(N,0:)   = ak*A%lmix(N,0:)
-    !
-    if(.not.C%anomalous)then
-       C%less(1:N-1,N)= -conjg(C%less(N,1:N-1))
-    else
-       C%less(1:N-1,N)= C%less(N,1:N-1)+C%ret(N,1:N-1)
-    endif
-    !
-    C%ret(N,N) = C%ret(N,N) + B(N)
-    !
-  end subroutine sum_kb_contour_gf_delta_d
-
-  subroutine sum_kb_contour_gf_delta_c(A,ak,B,bk,C,params)
-    type(kb_contour_gf)               :: A
-    complex(8),dimension(:)           :: B
-    type(kb_contour_gf),intent(inout) :: C
-    real(8)                           :: ak,bk
-    type(kb_contour_params)           :: params
-    integer                           :: N,L
-    if(  (.not.A%status).OR.&
-         (.not.C%status))stop "contour_gf/addup_kb_contour_gf: G or Gk not allocated"
-    !
-    N   = params%Nt   !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    !
-    call del_kb_contour_gf(C,params)
-    !
-    if(N==1)then 
-       C%mats(0)  = ak*A%mats(0)  + B(1)
-       C%mats(1:) = ak*A%mats(1:)
-       C%iw(:)    = ak*A%iw(:)    + B(1)
-    endif
-    !
-    C%ret(N,1:N)   = ak*A%ret(N,1:N)
-    C%less(N,1:N)  = ak*A%less(N,1:N)
-    C%lmix(N,0:)   = ak*A%lmix(N,0:)
-    !
-    if(.not.C%anomalous)then
-       C%less(1:N-1,N)= -conjg(C%less(N,1:N-1))
-    else
-       C%less(1:N-1,N)= C%less(N,1:N-1)+C%ret(N,1:N-1)
-    endif
-    !
-    C%ret(N,N) = C%ret(N,N) + B(N)
-    C%mats(0) = C%mats(0) + B(1)
-    !
-  end subroutine sum_kb_contour_gf_delta_c
-
-  subroutine sum_kb_contour_gf_recursive(A,ak,C,params,iaddup)
-    type(kb_contour_gf)               :: A(:)
-    real(8)                           :: ak(size(A))
-    type(kb_contour_gf),intent(inout) :: C
-    type(kb_contour_params)           :: params
-    integer                           :: N,L,Na,i
-    logical,optional                  :: iaddup
-    logical                           :: iaddup_
-    !
-    iaddup_=.false.;if(present(iaddup))iaddup_=iaddup
-    !
-    Na=size(A)
-    !
-    do i=1,Na
-       if((.not.A(i)%status) )stop "contour_gf/sum_kb_contour_gf: G or Gk not allocated"
-    enddo
-    if( (.not.C%status) )stop "contour_gf/addup_kb_contour_gf: G or Gk not allocated"
-    !
-    N   = params%Nt   !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    !
-    if(.not.iaddup_)call del_kb_contour_gf(C,params)
-    !
-    if(N==1)then
-       do i=1,Na
-          C%mats(0:) = C%mats(0:) + ak(i)*A(i)%mats(0:)
-          C%iw(:)    = C%iw(:)    + ak(i)*A(i)%iw(:)
-       enddo
-    endif
-    !
-    do i=1,Na
-       C%ret(N,1:N)   = C%ret(N,1:N)  + ak(i)*A(i)%ret(N,1:N)
-       C%less(N,1:N)  = C%less(N,1:N) + ak(i)*A(i)%less(N,1:N)
-       C%lmix(N,0:)   = C%lmix(N,0:)  + ak(i)*A(i)%lmix(N,0:)
-    enddo
-    !
-    if(.not.C%anomalous)then
-       C%less(1:N-1,N)= -conjg(C%less(N,1:N-1))
-    else
-       C%less(1:N-1,N)= C%less(N,1:N-1)+C%ret(N,1:N-1)
-    endif
-    !
-  end subroutine sum_kb_contour_gf_recursive
-
-
-
-
-
-
-
-  !======= DEL ======= 
-  ! reset the function along the actual perimeter to zero:
-  subroutine del_kb_contour_gf(G,params)
-    type(kb_contour_gf)     :: G
-    type(kb_contour_params) :: params
-    integer                 :: N,L
-    logical                 :: checkG
-    if(  (.not.G%status)) stop "contour_gf/addup_kb_contour_gf: G or Gk not allocated"
-    !
-    N   = params%Nt   !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    !
-    if(N==1)then
-       G%iw = zero
-       G%mats = 0d0
-    endif
-    !
-    G%ret(N,1:N)   = zero
-    G%less(N,1:N)  = zero
-    G%lmix(N,0:)   = zero
-  end subroutine del_kb_contour_gf
-
-  subroutine del_kb_contour_dgf(dG,params)
-    type(kb_contour_dgf)    :: dG
-    type(kb_contour_params) :: params
-    integer                 :: N,L
-    logical                 :: checkA,checkB,checkC
-    if(  (.not.dG%status))stop "contour_gf/del_kb_contour_dgf: dG not allocated"
-    !
-    N   = params%Nt                 !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    !
-    dG%less(1:N) = zero
-    dG%ret(1:N)  = zero
-    dG%lmix(0:)  = zero
-  end subroutine del_kb_contour_dgf
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  !======= EXTRAPOLATION ======= 
-  !extrapolate a function from a given time
-  !to the next one:
-  subroutine extrapolate_kb_contour_gf(g,params)
-    type(kb_contour_gf)     :: g
-    type(kb_contour_params) :: params
-    integer                 :: i,j,k,N,L
-    if(.not.g%status)     stop "extrapolate_kb_contour_gf: g is not allocated"
-    if(.not.params%status)stop "extrapolate_kb_contour_gf: params is not allocated"
-    !
-    N = params%Nt
-    L = params%Ntau
-    !
-    select case(N)
-    case(1)
-       return
-    case(2)
-       !GUESS G AT THE NEXT STEP, GIVEN THE INITIAL CONDITIONS
-       do j=1,N
-          g%ret(N,j) =g%ret(1,1)
-          g%less(N,j)=g%less(1,1)
-       end do
-       do i=1,N-1
-          g%less(i,N)=g%less(1,1)
-       end do
-       do j=0,L
-          g%lmix(N,j)=g%lmix(1,j)
-       end do
-    case default
-       !EXTEND G FROM THE [N-1,N-1] TO THE [N,N] SQUARE TO START DMFT
-       !USING QUADRATIC EXTRAPOLATION
-       do k=1,N-1
-          g%less(N,k)=2.d0*g%less(N-1,k)-g%less(N-2,k)
-          g%less(k,N)=2.d0*g%less(k,N-1)-g%less(k,N-2)
-       end do
-       g%less(N,N)=2.d0*g%less(N-1,N-1)-g%less(N-2,N-2)
-       !
-       do k=0,L
-          g%lmix(N,k)=2.d0*g%lmix(N-1,k)-g%lmix(N-2,k)
-       end do
-       !
-       g%ret(N,N)=-xi
-       do k=1,N-2
-          g%ret(N,k)=2.d0*g%ret(N-1,k)-g%ret(N-2,k)
-       end do
-       g%ret(N,N-1)=0.5d0*(g%ret(N,N)+g%ret(N,N-2))
-    end select
-  end subroutine extrapolate_kb_contour_gf
-
-
-
-
-
-
-
-
+  !======= SUM =======
+  ! performs the sum C=a*A + b*B along the perimeter t=N*dt & t'=0,N*dt
+  ! when called multiple times it sums up to a given array. 
+  include "neq_contour_gf_sum.f90"
 
 
 
   !======= CONVOLUTION ======= 
-  !C(t,t')=(A*B)(t,t'), with t=t_max && t'=0,t_max
-  !t_max_index==N
-  subroutine convolute_kb_contour_gf_simple(A,B,C,params,dcoeff,ccoeff)
-    type(kb_contour_gf)                 :: A,B,C
-    type(kb_contour_params)             :: params
-    real(8),optional                    :: dcoeff
-    complex(8),optional                 :: ccoeff
-    integer                             :: N,L
-    real(8)                             :: dt,dtau
-    complex(8),dimension(:),allocatable :: AxB    
-    integer                             :: i,j,k,itau,jtau
-    logical                             :: checkA,checkB,checkC
-    if(  (.not.A%status).OR.&
-         (.not.B%status).OR.&
-         (.not.C%status))stop "contour_gf/convolute_kb_contour_gf: A,B,C not allocated"
-    N   = params%Nt      !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    dt  = params%dt
-    dtau= params%dtau
-    !
-    checkA=check_dimension_kb_contour(A,params%Ntime,L) 
-    checkB=check_dimension_kb_contour(B,params%Ntime,L)
-    checkC=check_dimension_kb_contour(C,params%Ntime,L)
-    !
-    allocate(AxB(0:max(L,N)))
-    !
-    if(N==1) then
-       ! Matsubara frequencies
-       C%iw=A%iw*B%iw
-       ! Matsubara times
-       AxB(0:) = zero
-       do jtau=0,L
-          do k=0,jtau
-             AxB(k)=A%mats(k)*B%mats(L+k-jtau)
-          end do
-          C%mats(jtau)=C%mats(jtau)-dtau*kb_trapz(AxB(0:),0,jtau)
-          do k=jtau,L
-             AxB(k)=A%mats(k)*B%mats(k-jtau)
-          end do
-          C%mats(jtau)=C%mats(jtau)+dtau*kb_trapz(AxB(0:),jtau,L)
-       enddo
-    endif
-    !
-    !Ret. component
-    !C^R(t,t')=\int_{t'}^t ds A^R(t,s)*B^R(s,t')
-    C%ret(N,1:N)=zero
-    do j=1,N       !for all t' in 0:t_max
-       AxB(0:)  = zero !AxB should be set to zero before integration
-       do k=j,N    !store the convolution between t'{=j} and t{=N}
-          AxB(k) = A%ret(N,k)*B%ret(k,j)
-       enddo
-       C%ret(n,j) = C%ret(n,j) + dt*kb_trapz(AxB(0:),j,N)
-    enddo
-    !
-    !Lmix. component
-    !C^\lmix(t,tau')=\int_0^{beta} ds A^\lmix(t,s)*B^M(s,tau')
-    !                  +\int_0^{t} ds A^R(t,s)*B^\lmix(s,tau')
-    !               = I1 + I2
-    C%lmix(N,0:L)=zero
-    do jtau=0,L
-       !I1:
-       AxB(0:) = zero
-       !break the integral I1 in two parts to take care of the 
-       !sign of (tau-tau').
-       do k=0,jtau
-          AxB(k)=A%lmix(N,k)*B%mats(L+k-jtau)
-       end do
-       C%lmix(N,jtau)=C%lmix(N,jtau)-dtau*kb_trapz(AxB(0:),0,jtau)
-       do k=jtau,L
-          AxB(k)=A%lmix(N,k)*B%mats(k-jtau)
-       end do
-       C%lmix(n,jtau)=C%lmix(n,jtau)+dtau*kb_trapz(AxB(0:),jtau,L)
-       !
-       !I2:
-       AxB(0:) = zero
-       do k=1,N
-          AxB(k) = A%ret(N,k)*B%lmix(k,jtau)
-       enddo
-       C%lmix(N,jtau) = C%lmix(N,jtau) + dt*kb_trapz(AxB(0:),1,N)
-    enddo
-    !
-    !Less component
-    !C^<(t,t')=-i\int_0^{beta} ds A^\lmix(t,s)*B^\rmix(s,t')
-    !             +\int_0^{t'} ds A^<(t,s)*B^A(s,t')
-    !             +\int_0^{t} ds A^R(t,s)*B^<(s,t')
-    ! (t,t')=>(N,j) <==> Vertical side, with tip (j=1,N) !!no tip (j=1,N-1)
-    do j=1,N!-1
-       C%less(N,j)=zero
-       do k=0,L
-          !         AxB(k)=A%lmix(N,k)*conjg(B%lmix(j,L-k))
-          AxB(k)=A%lmix(N,k)*get_rmix(B,k,j,L)
-       end do
-       C%less(N,j)=C%less(N,j)-xi*dtau*kb_trapz(AxB(0:),0,L)
-       !
-       do k=1,j
-          !         AxB(k)=A%less(N,k)*conjg(B%ret(j,k))
-          AxB(k)=A%less(N,k)*get_adv(B,k,j)
-       end do
-       C%less(N,j)=C%less(N,j)+dt*kb_trapz(AxB(0:),1,j)
-       !
-       do k=1,N
-          AxB(k)=A%ret(N,k)*B%less(k,j)
-       end do
-       C%less(N,j)=C%less(N,j)+dt*kb_trapz(AxB(0:),1,N)
-    end do
-    !
-    ! (t,t`)=>(i,N) <==> Horizontal side, w/ no tip (i=1,N-1)
-    do i=1,N-1
-       C%less(i,N)=zero
-    enddo
-    ! do i=1,N
-    !    C%less(i,N)=zero
-    !    do k=0,L
-    !       !         AxB(k)=A%lmix(i,k)*conjg(B%lmix(n,L-k))
-    !       AxB(k)=A%lmix(i,k)*get_rmix(B,k,N,L)
-    !    end do
-    !    C%less(i,N)=C%less(i,N)-xi*dtau*kb_trapz(AxB(0:),0,L)
-    !    !
-    !    do k=1,N
-    !       !         AxB(k)=A%less(i,k)*conjg(B%ret(N,k))
-    !       AxB(k)=A%less(i,k)*get_adv(B,k,N)
-    !    end do
-    !    C%less(i,N)=C%less(i,N)+dt*kb_trapz(AxB(0:),1,N)
-    !    !
-    !    do k=1,i
-    !       AxB(k)=A%ret(i,k)*B%less(k,N)
-    !    end do
-    !    C%less(i,N)=C%less(i,N)+dt*kb_trapz(AxB(0:),1,i)
-    ! end do
-    !    
-    if(present(dcoeff))then
-       C%lmix(N,0:L) = dcoeff*C%lmix(N,0:L)
-       C%less(N,1:N-1)=dcoeff*C%less(N,1:N-1)
-       C%less(1:N,N)=dcoeff*C%less(1:N,N)
-       C%ret(N,1:N)=dcoeff*C%ret(N,1:N)
-    endif
-    if(present(ccoeff))then
-       C%lmix(N,0:L) = ccoeff*C%lmix(N,0:L)
-       C%less(N,1:N-1)=ccoeff*C%less(N,1:N-1)
-       C%less(1:N,N)=ccoeff*C%less(1:N,N)
-       C%ret(N,1:N)=ccoeff*C%ret(N,1:N)
-    endif
-    deallocate(AxB)
-  end subroutine convolute_kb_contour_gf_simple
-
-
-  subroutine convolute_kb_contour_gf_recursive(A,C,params,dcoeff,ccoeff)
-    type(kb_contour_gf)                 :: A(:)
-    type(kb_contour_gf)                 :: C
-    type(kb_contour_gf)                 :: Knew,Kold
-    type(kb_contour_params)             :: params
-    real(8),optional                    :: dcoeff
-    complex(8),optional                 :: ccoeff
-    integer                             :: N,L
-    integer                             :: i,j,k,itau,jtau,Na
-    logical                             :: checkA,checkC
-    !
-    Na = size(A)
-    !
-    if(  (.not.C%status))stop "contour_gf/convolute_kb_contour_gf: C not allocated"
-    do i=1,Na
-       if(  (.not.A(i)%status))stop "contour_gf/convolute_kb_contour_gf: A(i) not allocated"
-    enddo
-    !
-    call allocate_kb_contour_gf(Knew,params)
-    call allocate_kb_contour_gf(Kold,params)
-    !
-    N   = params%Nt      !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    !
-    checkC=check_dimension_kb_contour(C,params%Ntime,L)
-    do i=1,Na
-       checkA=check_dimension_kb_contour(A(i),params%Ntime,L) 
-    enddo
-    !
-    !Perform the recursive convolution:
-    Kold = A(1)
-    do i=2,Na-1
-       call convolute_kb_contour_gf(Kold,A(i),Knew,params)
-    enddo
-    call convolute_kb_contour_gf(Knew,A(Na),C,params)
-    !
-    if(present(dcoeff))then
-       C%lmix(N,0:L) = dcoeff*C%lmix(N,0:L)
-       C%less(N,1:N-1)=dcoeff*C%less(N,1:N-1)
-       C%less(1:N,N)=dcoeff*C%less(1:N,N)
-       C%ret(N,1:N)=dcoeff*C%ret(N,1:N)
-    endif
-    if(present(ccoeff))then
-       C%lmix(N,0:L) = ccoeff*C%lmix(N,0:L)
-       C%less(N,1:N-1)=ccoeff*C%less(N,1:N-1)
-       C%less(1:N,N)=ccoeff*C%less(1:N,N)
-       C%ret(N,1:N)=ccoeff*C%ret(N,1:N)
-    endif
-    call deallocate_kb_contour_gf(Knew)
-    call deallocate_kb_contour_gf(Kold)
-    !    
-  end subroutine convolute_kb_contour_gf_recursive
-
-
-  !======= CONVOLUTION WITH A FUNCTION MULTIPLIED BY THE DELTA FUNCTION======= 
-  !C(t,t')=(A*B)(t,t'), with t=t_max && t'=0,t_max
-  !t_max_index==N
-  ! In the case B(t,t')=B(t)delta(t,t')
-  subroutine convolute_kb_contour_gf_delta(A,B,C,params)
-    type(kb_contour_gf)                 :: A,C
-    complex(8),dimension(0:)            :: B
-    type(kb_contour_params)             :: params
-    integer                             :: N,L
-    real(8)                             :: dt,dtau
-    complex(8),dimension(:),allocatable :: AxB    
-    integer                             :: i,j,k,itau,jtau
-    logical                             :: checkA,checkC
-    if(  (.not.A%status).OR.&
-         (.not.C%status))stop "contour_gf/convolute_kb_contour_gf: A,B,C not allocated"
-    N   = params%Nt      !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    dt  = params%dt
-    dtau= params%dtau
-    !
-    checkA=check_dimension_kb_contour(A,params%Ntime,L) 
-    checkC=check_dimension_kb_contour(C,params%Ntime,L)
-    !
-    allocate(AxB(0:max(L,N)))
-    !
-    if (N.eq.1) then
-       ! Matsubara
-       C%mats = A%mats*B(0)
-    endif
-    !
-    do j=1,N
-       !Ret. component
-       C%ret(n,j) = A%ret(n,j)*B(j)
-       !Less. component
-       C%less(n,j) = A%less(n,j)*B(j)
-    enddo
-    ! do i=1,N-1
-    !    !Less. component
-    !    C%less(i,n)=A%less(i,N)*B(N)
-    ! enddo
-    !
-    !Lmix. component
-    do jtau=0,L
-       C%lmix(N,jtau) = A%lmix(N,jtau)*B(0)
-    enddo
-  end subroutine convolute_kb_contour_gf_delta
+  include "neq_contour_gf_convolute.f90"
 
 
 
+  !======= VOLTERRA INTEGRAL EQUATION =======
+  include "neq_contour_gf_vie.f90"
 
 
 
+  !======= VOLTERRA INTEGRO-DIFFERENTIAL EQUATION =======
+  include "neq_contour_gf_vide.f90"
 
 
 
+  !======= MISCELLANEOUS ======= 
+  ! CHECK DIMENSION
+  ! SAVE
+  ! READ
+  ! PLOT
+  ! EXTRAPOLATION
+  include "neq_contour_gf_misc.f90"
 
 
 
-
-  !======= VOLTERRA INTEGRAL EQUATION ======= 
-  !----------------------------------------------------------------------------
-  !  This subroutine solves a Volterra integral equation of the second kind,
-  !              G(t,t') = Q(t,t') + (K*G)(t,t')
-  !  for t=n*dt or t'=n*dt, using 2^nd *implicit* Runge-Kutta method.
-  !----------------------------------------------------------------------------
-  subroutine vie_kb_contour_gf_q(Q,K,G,params)
-    type(kb_contour_gf),intent(in)      :: Q
-    type(kb_contour_gf),intent(in)      :: K
-    type(kb_contour_gf),intent(inout)   :: G
-    type(kb_contour_params),intent(in)  :: params
-    integer                             :: N,L
-    real(8)                             :: dt,dtau
-    integer                             :: i,j,s,itau,jtau
-    complex(8),dimension(:),allocatable :: KxG
-    !
-    N   = params%Nt                 !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    dt  = params%dt
-    dtau= params%dtau
-    !
-    allocate(KxG(0:max(N,L)))
-    !
-    ! Ret component
-    ! G^R(t,t') - \int_{t'}^t K^R(t,s)*G^R(s,t')ds = Q^R(t,t')
-    G%ret(N,N)=Q%ret(N,N)
-    do j=1,N-1
-       G%ret(N,j)=Q%ret(N,j)
-       do s=j,N-1
-          KxG(s)=K%ret(N,s)*G%ret(s,j)
-       eNd do
-       G%ret(N,j)=G%ret(N,j) + dt*kb_half_trapz(KxG(0:),j,N-1)
-       G%ret(N,j)=G%ret(N,j)/(1.d0-0.5d0*dt*K%ret(N,N))
-    end do
-    !
-    ! Lmix component
-    ! G^\lmix(t,tau') - \int_0^t K^R(t,s)*G^\lmix(s,tau')ds
-    !    = Q^\lmix(t,tau') + \int_0^\beta K^\lmix(t,s)*G^M(s,tau')ds
-    do jtau=0,L
-       G%lmix(N,jtau)=Q%lmix(N,jtau)
-       do s=0,jtau
-          KxG(s)=K%lmix(N,s)*G%mats(s+L-jtau)
-       end do
-       G%lmix(N,jtau)=G%lmix(N,jtau)-dtau*kb_trapz(KxG(0:),0,jtau)
-       do s=jtau,L
-          KxG(s)=K%lmix(N,s)*G%mats(s-jtau)
-       end do
-       G%lmix(N,jtau)=G%lmix(N,jtau)+dtau*kb_trapz(KxG(0:),jtau,L)
-       !
-       do s=1,N-1
-          KxG(s)=K%ret(N,s)*G%lmix(s,jtau)
-       end do
-       G%lmix(N,jtau)=G%lmix(N,jtau) + dt*kb_half_trapz(KxG(0:),1,N-1)
-       G%lmix(N,jtau)=G%lmix(N,jtau)/(1.d0-0.5d0*dt*K%ret(N,N))
-    end do
-    !
-    ! Less component
-    ! G^<(t,t') - \int_0^t K^{R}(t,s)*G^{<}(s,t')ds
-    !    = Q^<(t,t') - i\int_0^\beta K^\lmix(t,s)*G^\rmix(s,t')ds
-    !      + \int_0^{t'} K^<(t,s)*G^A(s,t')ds
-    ! G^<(t_{N},t_{j})
-    do j=1, N-1
-       G%less(N,j)=Q%less(N,j)
-       do s=0,L
-          !         KxG(s)=K%lmix(N,s)*conjg(G%lmix(j,L-s))
-          KxG(s)=K%lmix(N,s)*get_rmix(G,s,j,L)
-       enddo
-       G%less(N,j)=G%less(N,j)-xi*dtau*kb_trapz(KxG(0:),0,L)
-       !
-       do s=1,j
-          !         KxG(s)=K%less(N,s)*conjg(G%ret(j,s))
-          KxG(s)=K%less(N,s)*get_adv(G,s,j)
-       enddo
-       G%less(N,j)=G%less(N,j)+dt*kb_trapz(KxG(0:),1,j)
-       !
-       do s=1,N-1
-          KxG(s)=K%ret(N,s)*G%less(s,j)
-       enddo
-       G%less(N,j)=G%less(N,j) + dt*kb_half_trapz(KxG(0:),1,N-1)
-       G%less(N,j)=G%less(N,j)/(1.d0-0.5d0*dt*K%ret(N,N))
-    end do
-    !
-    ! G^<(t_{i},t_{N}) <= Hermite conjugate
-    if (.not.G%anomalous) then
-       do i=1,N-1
-          G%less(i,N) = -conjg(G%less(N,i))
-       end do
-    else
-       do i=1,N-1
-          G%less(i,N) = G%less(N,i)+G%ret(N,i)
-       end do
-    endif
-    !
-    ! G^{<}(t_{n},t_{n}) <= Diagonal
-    G%less(N,N)=Q%less(N,N)
-    do s=0,L
-       !      KxG(s)=K%lmix(N,s)*conjg(G%lmix(N,L-s))
-       KxG(s)=K%lmix(N,s)*get_rmix(G,s,N,L)
-    end do
-    G%less(N,N)=G%less(N,N)-xi*dtau*kb_trapz(KxG(0:),0,L)
-    !
-    do s=1,N
-       !      KxG(s)=K%less(N,s)*conjg(G%ret(N,s))
-       KxG(s)=K%less(N,s)*get_adv(G,s,N)
-    end do
-    G%less(N,N)=G%less(N,N)+dt*kb_trapz(KxG(0:),1,N)
-    !
-    do s=1,N-1
-       KxG(s)=K%ret(N,s)*G%less(s,N)
-    end do
-    G%less(N,N)=G%less(N,N) + dt*kb_half_trapz(KxG(0:),1,N-1)
-    G%less(N,N)=G%less(N,N)/(1.d0-0.5d0*dt*K%ret(N,N))
-    !
-    deallocate(KxG)
-    !
-  end subroutine vie_kb_contour_gf_q
-
-  subroutine vie_kb_contour_gf_delta(K,G,params)
-    type(kb_contour_gf),intent(in)      :: K
-    type(kb_contour_gf),intent(inout)   :: G
-    type(kb_contour_params),intent(in)  :: params
-    integer                             :: N,L
-    real(8)                             :: dt,dtau
-    integer                             :: i,j,s,itau,jtau
-    complex(8),dimension(:),allocatable :: KxG
-    !
-    N   = params%Nt                 !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    dt  = params%dt
-    dtau= params%dtau
-    !
-    allocate(KxG(0:max(N,L)))
-    !
-    ! Ret component
-    ! G^R(t,t') - \int_{t'}^t K^R(t,s)*G^R(s,t')ds = Q^R(t,t')
-    G%ret(N,N)=one!Q%ret(N,N)
-    do j=1,N-1
-       G%ret(N,j)=zero!Q%ret(N,j)
-       do s=j,N-1
-          KxG(s)=K%ret(N,s)*G%ret(s,j)
-       eNd do
-       G%ret(N,j)=G%ret(N,j) + dt*kb_half_trapz(KxG(0:),j,N-1)
-       G%ret(N,j)=G%ret(N,j)/(1.d0-0.5d0*dt*K%ret(N,N))
-    end do
-    !
-    ! Lmix component
-    ! G^\lmix(t,tau') - \int_0^t K^R(t,s)*G^\lmix(s,tau')ds
-    !    = Q^\lmix(t,tau') + \int_0^\beta K^\lmix(t,s)*G^M(s,tau')ds
-    do jtau=0,L
-       G%lmix(N,jtau)=zero!Q%lmix(N,jtau)
-       do s=0,jtau
-          KxG(s)=K%lmix(N,s)*G%mats(s+L-jtau)
-       end do
-       G%lmix(N,jtau)=G%lmix(N,jtau)-dtau*kb_trapz(KxG(0:),0,jtau)
-       do s=jtau,L
-          KxG(s)=K%lmix(N,s)*G%mats(s-jtau)
-       end do
-       G%lmix(N,jtau)=G%lmix(N,jtau)+dtau*kb_trapz(KxG(0:),jtau,L)
-       !
-       do s=1,N-1
-          KxG(s)=K%ret(N,s)*G%lmix(s,jtau)
-       end do
-       G%lmix(N,jtau)=G%lmix(N,jtau) + dt*kb_half_trapz(KxG(0:),1,N-1)
-       G%lmix(N,jtau)=G%lmix(N,jtau)/(1.d0-0.5d0*dt*K%ret(N,N))
-    end do
-    !
-    ! Less component
-    ! G^<(t,t') - \int_0^t K^{R}(t,s)*G^{<}(s,t')ds
-    !    = Q^<(t,t') - i\int_0^\beta K^\lmix(t,s)*G^\rmix(s,t')ds
-    !      + \int_0^{t'} K^<(t,s)*G^A(s,t')ds
-    ! G^<(t_{N},t_{j})
-    do j=1, N-1
-       G%less(N,j)=zero!Q%less(N,j)
-       do s=0,L
-          !         KxG(s)=K%lmix(N,s)*conjg(G%lmix(j,L-s))
-          KxG(s)=K%lmix(N,s)*get_rmix(G,s,j,L)
-       enddo
-       G%less(N,j)=G%less(N,j)-xi*dtau*kb_trapz(KxG(0:),0,L)
-       !
-       do s=1,j
-          !         KxG(s)=K%less(N,s)*conjg(G%ret(j,s))
-          KxG(s)=K%less(N,s)*get_adv(G,s,j)
-       enddo
-       G%less(N,j)=G%less(N,j)+dt*kb_trapz(KxG(0:),1,j)
-       !
-       do s=1,N-1
-          KxG(s)=K%ret(N,s)*G%less(s,j)
-       enddo
-       G%less(N,j)=G%less(N,j) + dt*kb_half_trapz(KxG(0:),1,N-1)
-       G%less(N,j)=G%less(N,j)/(1.d0-0.5d0*dt*K%ret(N,N))
-    end do
-    !
-    ! G^<(t_{i},t_{N}) <= Hermite conjugate
-    if (.not.G%anomalous) then
-       do i=1,N-1
-          G%less(i,N) = -conjg(G%less(N,i))
-       end do
-    else
-       do i=1,N-1
-          G%less(i,N) = G%less(N,i)+G%ret(N,i)
-       end do
-    endif
-    !
-    ! G^{<}(t_{n},t_{n}) <= Diagonal
-    G%less(N,N)=zero!Q%less(N,N)
-    do s=0,L
-       !      KxG(s)=K%lmix(N,s)*conjg(G%lmix(N,L-s))
-       KxG(s)=K%lmix(N,s)*get_rmix(G,s,N,L)
-    end do
-    G%less(N,N)=G%less(N,N)-xi*dtau*kb_trapz(KxG(0:),0,L)
-    !
-    do s=1,N
-       !      KxG(s)=K%less(N,s)*conjg(G%ret(N,s))
-       KxG(s)=K%less(N,s)*get_adv(G,s,N)
-    end do
-    G%less(N,N)=G%less(N,N)+dt*kb_trapz(KxG(0:),1,N)
-    !
-    do s=1,N-1
-       KxG(s)=K%ret(N,s)*G%less(s,N)
-    end do
-    G%less(N,N)=G%less(N,N) + dt*kb_half_trapz(KxG(0:),1,N-1)
-    G%less(N,N)=G%less(N,N)/(1.d0-0.5d0*dt*K%ret(N,N))
-    !
-    deallocate(KxG)
-    !
-  end subroutine vie_kb_contour_gf_delta
+  !======= OPERATIONS =======
+  ! .*. times a scalar
+  ! .=. equality among GF
+  ! +get_Adv
+  ! +get_Gtr
+  ! +get_Rmix
+  ! +get_Bar
+  include "neq_contour_gf_operations.f90"
 
 
 
-
-
-
-
-
-  !======= VOLTERRA INTEGRO-DIFFERENTIAL EQUATION ======= 
-  !----------------------------------------------------------------------------
-  !  This subroutine solves a Volterra integro-differential equation of 
-  !  the second kind,
-  !              [i*d/dt-h(t)]G(t,t') = delta(t,t') + (K*G)(t,t'),
-  !  for t=n*dt or t'=n*dt, using 2^nd implicit Runge-Kutta method.
-  !----------------------------------------------------------------------------
-  subroutine vide_kb_contour_gf(H,K,G,dG,dG_new,params)
-    complex(8),dimension(:)             :: H
-    type(kb_contour_gf),intent(in)      :: K
-    type(kb_contour_gf),intent(inout)   :: G
-    type(kb_contour_dgf),intent(inout)  :: dG
-    type(kb_contour_dgf)                :: dG_new
-    type(kb_contour_params),intent(in)  :: params
-    integer                             :: N,L
-    real(8)                             :: dt,dtau
-    integer                             :: i,j,itau,jtau,s
-    complex(8),dimension(:),allocatable :: KxG
-    complex(8)                          :: dG_less,A
-    !
-    N   = params%Nt                 !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    dt  = params%dt
-    dtau= params%dtau
-    !call allocate_kb_contour_dgf(dG_new,params)
-    !
-    allocate(KxG(0:max(N,L)))
-    !
-    !TYPE: X=RET,LESS,LMIX (R,<,\LMIX)
-    !I D/DT G^X(T,:)  = H(T)G^X(T,:) + Q^X(T,:) + INT_{0,T'}^{T}K^R(T,S)G^X(S,:)DS
-    !
-    !Ret component
-    ! d/dt G^R(t,:) = -i*h(t)*G^R(t,:) -i*delta(t,:) - i\int_{:}^t K^R(t,s)*G^R(s,:)ds
-    G%ret(N,N)=-xi
-    dG_new%ret(N)=-xi*H(N)*G%ret(N,N)
-    do j=1,N-1
-       G%ret(N,j)=G%ret(N-1,j) + 0.5d0*dt*dG%ret(j)
-       do s=j,N-1
-          KxG(s)=K%ret(N,s)*G%ret(s,j)
-       enddo
-       dG_new%ret(j)=-xi*dt*kb_half_trapz(KxG(0:),j,N-1)
-       !
-       G%ret(N,j)=G%ret(N,j) + 0.5d0*dt*dG_new%ret(j)
-       G%ret(N,j)=G%ret(N,j)/(1.d0 + 0.5d0*xi*dt*H(N) + 0.25d0*xi*dt**2*K%ret(N,N))
-       !
-       dG_new%ret(j)=dG_new%ret(j) - xi*H(N)*G%ret(N,j) - 0.5d0*xi*dt*K%ret(N,N)*G%ret(N,j)
-    enddo
-    !
-    !Lmix component
-    !d/dt G^\lmix(t,:) = -i*H(t)*G^\lmix(t,:) -i\int_0^\beta K^\lmix(t,s)*G^M(s,:)ds -i\int_0^t K^R(t,s)G^\lmix(s,:)ds
-    do jtau=0,L
-       G%lmix(N,jtau)=G%lmix(N-1,jtau)+0.5d0*dt*dG%lmix(jtau)
-       do s=0,jtau
-          KxG(s)=K%lmix(N,s)*G%mats(s+L-jtau)
-       end do
-       dG_new%lmix(jtau)=xi*dtau*kb_trapz(KxG(0:),0,jtau)
-       do s=jtau,L
-          KxG(s)=K%lmix(N,s)*G%mats(s-jtau)
-       end do
-       dG_new%lmix(jtau)=dG_new%lmix(jtau)-xi*dtau*kb_trapz(KxG(0:),jtau,L)!<= add -iQ(t)
-       !
-       do s=1,N-1
-          KxG(s)=K%ret(N,s)*G%lmix(s,jtau)
-       end do
-       dG_new%lmix(jtau)=dG_new%lmix(jtau)-xi*dt*kb_half_trapz(KxG(0:),1,N-1)
-       !
-       G%lmix(N,jtau)=G%lmix(N,jtau) + 0.5d0*dt*dG_new%lmix(jtau)
-       G%lmix(N,jtau)=G%lmix(N,jtau)/(1.d0 + 0.5d0*xi*dt*H(N) + 0.25d0*xi*dt**2*K%ret(N,N))
-       !
-       dG_new%lmix(jtau)=dG_new%lmix(jtau)-xi*H(N)*G%lmix(N,jtau)-0.5d0*xi*dt*K%ret(N,N)*G%lmix(N,jtau)
-    end do
-    !
-    !Less component
-    !d/dt G^<(t,:) = -i*H(t)*G^<(t,:) -i*[ (-i)*\int_0^\beta K^\lmix(t,s)*G^\rmix(s,:)ds + \int_0^{:}K^<(t,s)*G^A(s,:)ds ]
-    !                                 -i*\int_0^t K^R(t,s)*G^<(s,:)ds
-    !
-    ! G^<(t_{N},t_{j}), d/dt G^<(t_{N},t_{j}) <== lower-right triangle
-    do j=1,N-1
-       G%less(N,j)=G%less(N-1,j) + 0.5d0*dt*dG%less(j)
-       do s=0,L
-          !         KxG(s)=K%lmix(N,s)*conjg(G%lmix(j,L-s))
-          KxG(s)=K%lmix(N,s)*get_rmix(G,s,j,L)
-       end do
-       dG_new%less(j)=-xi*(-xi)*dtau*kb_trapz(KxG(0:),0,L)
-       do s=1,j
-          !         KxG(s)=K%less(N,s)*conjg(G%ret(j,s))
-          KxG(s)=K%less(N,s)*get_adv(G,s,j)
-       end do
-       dG_new%less(j)=dG_new%less(j)-xi*dt*kb_trapz(KxG(0:),1,j)!<= -iQ(t)
-       !
-       do s=1,N-1
-          KxG(s)=K%ret(N,s)*G%less(s,j)
-       end do
-       dG_new%less(j)=dG_new%less(j)-xi*dt*kb_half_trapz(KxG(0:),1,N-1)
-       !
-       G%less(N,j)=G%less(N,j) + 0.5d0*dt*dG_new%less(j)
-       G%less(N,j)=G%less(N,j)/(1.d0 + 0.5d0*xi*dt*H(N) + 0.25d0*xi*dt**2*K%ret(N,N))
-       !
-       dG_new%less(j)=dG_new%less(j)-xi*H(N)*G%less(N,j)-0.5d0*xi*dt*K%ret(N,N)*G%less(N,j)
-    end do
-    !
-    ! G^<(t_{i},t_{N}), d/dt G^<(t_{i},t_{N}) <== upper left triangle
-    ! Hermitian conjugate G
-    if (.not.G%anomalous) then
-       do i=1,N-1
-          G%less(i,N)=-conjg(G%less(N,i))
-       end do
-    else
-       do i=1,N-1
-          G%less(i,N)=G%less(N,i)+G%ret(N,i)
-       end do
-    endif
-    !
-    ! d/dt G^<(t_{N-1},t_{N})
-    dG_less=-xi*H(N-1)*G%less(N-1,N)
-    do s=0,L
-       !      KxG(s)=K%lmix(N-1,s)*conjg(G%lmix(N,L-s))
-       KxG(s)=K%lmix(N-1,s)*get_rmix(G,s,N,L)
-    end do
-    dG_less=dG_less-xi*(-xi)*dtau*kb_trapz(KxG(0:),0,L)
-    do s=1,N
-       !      KxG(s)=K%less(N-1,s)*conjg(G%ret(N,s))
-       KxG(s)=K%less(N-1,s)*get_adv(G,s,N)
-    end do
-    dG_less=dG_less-xi*dt*kb_trapz(KxG(0:),1,N)
-    do s=1,N-1
-       KxG(s)=K%ret(N-1,s)*G%less(s,N)
-    end do
-    dG_less=dG_less-xi*dt*kb_trapz(KxG(0:),1,N-1)
-    !
-    !G^<(N,N), d/dt G^<(N,N)
-    G%less(N,N)=G%less(N-1,N)+0.5d0*dt*dG_less
-    do s=0,L
-       !      KxG(s)=K%lmix(N,s)*conjg(G%lmix(N,L-s))
-       KxG(s)=K%lmix(N,s)*get_rmix(G,s,N,L)
-    end do
-    dG_new%less(N)=-xi*(-xi)*dtau*kb_trapz(KxG(0:),0,L)
-    !
-    do s=1,N
-       !      KxG(s)=K%less(N,s)*conjg(G%ret(N,s))
-       KxG(s)=K%less(N,s)*get_adv(G,s,N)
-    end do
-    dG_new%less(N)=dG_new%less(N)-xi*dt*kb_trapz(KxG(0:),1,N)
-    !
-    do s=1,N-1
-       KxG(s)=K%ret(N,s)*G%less(s,N)
-    end do
-    dG_new%less(N)=dG_new%less(N)-xi*dt*kb_half_trapz(KxG(0:),1,N-1)
-    !
-    G%less(N,N)=G%less(N,N)+0.5d0*dt*dG_new%less(N)
-    G%less(N,N)=G%less(N,N)/(1.d0+0.5d0*xi*dt*H(N)+0.25d0*xi*dt**2*K%ret(N,N))
-    !
-    dG_new%less(N)=dG_new%less(N)-xi*H(N)*G%less(N,N)-0.5d0*xi*dt*K%ret(N,N)*G%less(N,N)
-    !
-    !d/dt G <== d/dt G_new
-    ! dG=dG_new
-    ! call deallocate_kb_contour_dgf(dG_new)
-    deallocate(KxG)
-    !
-  end subroutine vide_kb_contour_gf
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  !======= INTEGRATION =======
   !----------------------------------------------------------------------------
   !  This function calculates the sum
   !    \sum_{k=i}^{j} w_{k}^{i,j} f_{k}.
@@ -1603,7 +267,7 @@ contains
        sum=sum+0.5d0*f(ib)
     end if
   end function kb_trapz_d
-
+  !
   function kb_trapz_c(f,ia,ib,origin) result(sum)
     complex(8),dimension(0:),intent(in) :: f
     integer,intent(in)                 :: ia, ib
@@ -1612,13 +276,10 @@ contains
     logical,optional,intent(in)        :: origin
     logical                            :: w0
     real(8)                            :: w
-
     w0=.true.
     if(present(origin)) w0=origin
-
     w = 0.5d0
     if(.not.w0) w = 1d0
-
     sum=zero
     if(ia==ib)then
        return
@@ -1630,7 +291,7 @@ contains
        sum=sum+w*f(ib)
     end if
   end function kb_trapz_c
-
+  !
   function kb_half_trapz_d(f,ia,ib) result(sum)
     real(8),dimension(0:),intent(in) :: f
     integer,intent(in)              :: ia, ib
@@ -1658,269 +319,5 @@ contains
 
 
 
-
-
-
-
-
-  !======= OPERATIONS + & * ======= 
-  subroutine kb_contour_gf_equality_(G1,C)
-    type(kb_contour_gf),intent(inout) :: G1
-    complex(8),intent(in)             :: C
-    G1%less(:,:)  = C
-    G1%ret(:,:)   = C
-    G1%lmix(:,0:) = C
-    G1%mats(0:)   = C
-    G1%iw(:)      = C
-  end subroutine kb_contour_gf_equality_
-  !
-  subroutine kb_contour_gf_equality__(G1,G2)
-    type(kb_contour_gf),intent(inout) :: G1
-    type(kb_contour_gf),intent(in)    :: G2
-    G1%less(:,:)  = G2%less(:,:)
-    G1%ret(:,:)   = G2%ret(:,:)
-    G1%lmix(:,0:) = G2%lmix(:,0:)
-    G1%mats(0:)   = G2%mats(0:)
-    G1%iw(:)      = G2%iw(:)
-  end subroutine kb_contour_gf_equality__
-  !
-  subroutine kb_contour_dgf_equality_(dG1,C)
-    type(kb_contour_dgf),intent(inout) :: dG1
-    complex(8),intent(in)             :: C
-    dG1%less(:)  = C
-    dG1%ret(:)   = C
-    dG1%lmix(0:) = C
-  end subroutine kb_contour_dgf_equality_
-  !
-  subroutine kb_contour_dgf_equality__(dG1,dG2)
-    type(kb_contour_dgf),intent(inout) :: dG1
-    type(kb_contour_dgf),intent(in)    :: dG2
-    dG1%less(:)  = dG2%less(:)
-    dG1%ret(:)   = dG2%ret(:)
-    dG1%lmix(0:) = dG2%lmix(0:)
-  end subroutine kb_contour_dgf_equality__
-
-
-
-  function kb_contour_gf_scalarL_d(C,G) result(F)
-    real(8),intent(in)             :: C
-    type(kb_contour_gf),intent(in) :: G
-    type(kb_contour_gf)            :: F
-    F%less(:,:) = C*G%less(:,:)
-    F%ret(:,:)  = C*G%ret(:,:)
-    F%lmix(:,0:)= C*G%lmix(:,0:)
-    F%mats(0:)  = C*G%mats(0:)
-    F%iw(:)     = C*G%iw(:)
-  end function kb_contour_gf_scalarL_d
-  !
-  function kb_contour_dgf_scalarL_d(C,dG) result(dF)
-    real(8),intent(in)             :: C
-    type(kb_contour_dgf),intent(in) :: dG
-    type(kb_contour_dgf)            :: dF
-    dF%less(:) = C*dG%less(:)
-    dF%ret(:)  = C*dG%ret(:)
-    dF%lmix(0:)= C*dG%lmix(0:)
-  end function kb_contour_dgf_scalarL_d
-
-
-
-  function kb_contour_gf_scalarL_c(C,G) result(F)
-    complex(8),intent(in)          :: C
-    type(kb_contour_gf),intent(in) :: G
-    type(kb_contour_gf)            :: F
-    F%less(:,:) = C*G%less(:,:)
-    F%ret(:,:)  = C*G%ret(:,:)
-    F%lmix(:,0:)= C*G%lmix(:,0:)
-    F%mats(0:)  = C*G%mats(0:)
-    F%iw(:)     = C*G%iw(:)
-  end function kb_contour_gf_scalarL_c
-  !
-  function kb_contour_dgf_scalarL_c(C,dG) result(dF)
-    complex(8),intent(in)           :: C
-    type(kb_contour_dgf),intent(in) :: dG
-    type(kb_contour_dgf)            :: dF
-    dF%less(:) = C*dG%less(:)
-    dF%ret(:)  = C*dG%ret(:)
-    dF%lmix(0:)= C*dG%lmix(0:)
-  end function kb_contour_dgf_scalarL_c
-
-
-
-
-
-  function kb_contour_gf_scalarR_d(G,C) result(F)
-    real(8),intent(in)             :: C
-    type(kb_contour_gf),intent(in) :: G
-    type(kb_contour_gf)            :: F
-    F%less(:,:) = G%less(:,:)*C
-    F%ret(:,:)  = G%ret(:,:)*C
-    F%lmix(:,0:)= G%lmix(:,0:)*C
-    F%mats(0:)  = G%mats(0:)*C
-    F%iw(:)     = G%iw(:)*C
-  end function kb_contour_gf_scalarR_d
-  !
-  function kb_contour_dgf_scalarR_d(dG,C) result(dF)
-    real(8),intent(in)             :: C
-    type(kb_contour_dgf),intent(in) :: dG
-    type(kb_contour_dgf)            :: dF
-    dF%less(:) = dG%less(:)*C
-    dF%ret(:)  = dG%ret(:)*C
-    dF%lmix(0:)= dG%lmix(0:)*C
-  end function kb_contour_dgf_scalarR_d
-
-
-
-
-  function kb_contour_gf_scalarR_c(G,C) result(F)
-    complex(8),intent(in)             :: C
-    type(kb_contour_gf),intent(in) :: G
-    type(kb_contour_gf)            :: F
-    F%less(:,:) = G%less(:,:)*C
-    F%ret(:,:)  = G%ret(:,:)*C
-    F%lmix(:,0:)= G%lmix(:,0:)*C
-    F%mats(0:)  = G%mats(0:)*C
-    F%iw(:)     = G%iw(:)*C
-  end function kb_contour_gf_scalarR_c
-  !
-  function kb_contour_dgf_scalarR_c(dG,C) result(dF)
-    complex(8),intent(in)             :: C
-    type(kb_contour_dgf),intent(in) :: dG
-    type(kb_contour_dgf)            :: dF
-    dF%less(:) = dG%less(:)*C
-    dF%ret(:)  = dG%ret(:)*C
-    dF%lmix(0:)= dG%lmix(0:)*C
-  end function kb_contour_dgf_scalarR_c
-
-  function get_adv(G,i,j) result (adv)
-    implicit none
-    type(kb_contour_gf),intent(in) :: G
-    integer :: i,j
-    complex(8) :: adv
-    if (.not.G%anomalous) then
-       adv=conjg(G%ret(j,i))
-       return
-    else
-       adv=G%ret(j,i)
-       return
-    endif
-  end function get_adv
-
-  function get_rmix(G,i,j,L) result (rmix)
-    implicit none
-    type(kb_contour_gf),intent(in) :: G
-    integer :: i,j,L
-    complex(8) :: rmix
-    if (.not.G%anomalous) then
-       rmix=conjg(G%lmix(j,L-i))
-       return
-    else
-       rmix=G%lmix(j,i)
-       return
-    endif
-  end function get_rmix
-
-  function get_gtr(G,i,j) result (gtr)
-    implicit none
-    type(kb_contour_gf),intent(in) :: G
-    integer :: i,j
-    complex(8) :: gtr
-    if (.not.G%anomalous) then
-       if (i.ge.j) then
-          gtr=G%less(i,j)+G%ret(i,j)
-          return
-       else
-          gtr=G%less(i,j)-conjg(G%ret(j,i))
-          return
-       endif
-    else
-       gtr=G%less(j,i)
-       return
-    endif
-  end function get_gtr
-
-
-  !+-----------------------------------------------------------------------------+!
-  !PURPOSE:  comment
-  !+-----------------------------------------------------------------------------+!
-  subroutine get_bar(A,B,params)
-    type(kb_contour_gf)                 :: A,B
-    type(kb_contour_params)             :: params
-    integer                             :: N,L,Lf
-    real(8)                             :: dt,dtau
-    integer                             :: i,j,k,itau,jtau
-    logical                             :: checkA,checkB,checkC
-
-    if(  (.not.A%status).OR.&
-         (.not.B%status))stop "contour_gf/get_bar_kb_contour_gf: A,B,C not allocated"
-    N   = params%Nt      !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    Lf  = params%Niw
-    dt  = params%dt
-    dtau= params%dtau
-    !
-    checkA=check_dimension_kb_contour(A,params%Ntime,L) 
-    checkB=check_dimension_kb_contour(B,params%Ntime,L)
-    !
-    if(N==1)then
-       ! Matsubara imaginary time component
-       if (.not.B%anomalous) then
-          A%mats(0:L) = B%mats(L:0:-1)
-       else
-          A%mats(0:L) = B%mats(0:L)
-       endif
-       !
-       ! Matsubara frequencies component
-       if (.not.B%anomalous) then
-          A%iw = -conjg(B%iw)
-       else
-          A%iw = B%iw
-       endif
-    endif
-    !
-    !
-    !Ret. component
-    if (.not.B%anomalous) then
-       do j=1,N
-          A%ret(n,j) = -conjg(B%ret(n,j))
-       enddo
-    else
-       do j=1,N
-          A%ret(n,j) =  conjg(B%ret(n,j))
-       enddo
-    endif
-    !
-    !Lmix. component
-    if (.not.B%anomalous) then
-       do jtau=0,L
-          A%lmix(N,jtau) = -conjg(B%lmix(N,L-jtau))
-       enddo
-    else
-       do jtau=0,L
-          A%lmix(N,jtau) =  B%lmix(N,L-jtau)
-       enddo
-    endif
-    !
-    !Less component
-    if (.not.B%anomalous) then
-       do j=1,N-1
-          A%less(N,j)=-B%less(j,N)+conjg(B%ret(N,j))
-       end do
-    else
-       do j=1,N-1
-          A%less(N,j)=-conjg(B%less(j,N))
-       end do
-    endif
-    !
-    ! (t,t')=>(i,N) <==> Horizontal side, w/ tip (i=1,N)
-    if (.not.B%anomalous) then
-       do j=1,N-1
-          A%less(j,N)=-B%less(N,j)-B%ret(N,j)
-       end do
-    else
-       do j=1,N-1
-          B%less(N,j)=-conjg(B%less(j,N))
-       end do
-    endif
-  end subroutine get_bar
 END MODULE NEQ_CONTOUR_GF
 

--- a/NEQ_EQUILIBRIUM.f90
+++ b/NEQ_EQUILIBRIUM.f90
@@ -10,224 +10,20 @@ module NEQ_EQUILIBRIUM
   USE DMFT_MISC
   private
 
-  interface neq_continue_equilibirum
-     module procedure neq_continue_equilibirum_normal
-     module procedure neq_continue_equilibirum_bethe
-  end interface neq_continue_equilibirum
 
+  interface neq_continue_equilibirum
+     module procedure neq_continue_equilibirum_normal_lattice
+     module procedure neq_continue_equilibirum_normal_bethe
+  end interface neq_continue_equilibirum
   public  :: neq_continue_equilibirum     ! read G0 and continue the equilibrium GF,Sigma,G0 to the t=0 contour.
+
+
+  interface neq_setup_initial_conditions
+     module procedure neq_setup_initial_conditions_normal
+  end interface neq_setup_initial_conditions
   public  :: neq_setup_initial_conditions ! setup the initial conditions for the e/k dependent GF.
 
-
-  real(8),allocatable,dimension(:)    :: Rtau
-  complex(8),allocatable,dimension(:) :: Riw
-
-
 contains
-
-
-  !+-------------------------------------------------------------------+
-  !PURPOSE: obtain and continue the  equilibrium to Keldysh contour
-  !+-------------------------------------------------------------------+
-  subroutine neq_continue_equilibirum_normal(g0,gk,dgk,g,selfHF,self,Hk,Wtk,params)
-    type(kb_contour_gf)                 :: g0
-    type(kb_contour_gf)                 :: gk(:)
-    type(kb_contour_dgf)                :: dgk(size(gk))
-    type(kb_contour_gf)                 :: g
-    type(kb_contour_gf)                 :: self
-    complex(8)                          :: selfHF(:)
-    type(kb_contour_params)             :: params
-    real(8)                             :: Hk(size(gk)),Wtk(size(gk))
-    real(8)                             :: wm,res,ims
-    logical                             :: bool
-    integer                             :: i,j,k,ik,unit,len,N,L,Lf,Lk
-    complex(8)                          :: zeta
-    complex(8)                          :: Self_gtr
-    complex(8),allocatable,dimension(:) :: SxG
-    Lk=size(gk)
-    if(.not.g0%status)stop "init_functions: g0 is not allocated"
-    if(.not.g%status)stop "init_functions: g is not allocated"
-    do ik=1,Lk
-       if(.not.gk(ik)%status)stop "init_functions: gk(ik) is not allocated"
-       if(.not.dgk(ik)%status)stop "init_functions: dgk(ik) is not allocated"
-    enddo
-    if(.not.self%status)stop "init_functions: self is not allocated"
-    if(.not.params%status)stop "init_functions: params is not allocated"
-    if(size(selfHF)/=params%Ntime)stop "init_functions: size(selfHF)!=Ntime"
-    !
-    N = params%Nt
-    L = params%Ntau
-    Lf= params%Niw
-    !
-    !INITIALIZE THE SELF-ENERGY SELF^{x=M,<,R,\lmix}
-    call read_equilibrium_sigma_normal(selfHF,self,params)            !<== get Sigma^{x=iw,tau,M,<,R,\lmix}
-    !
-    !INITIALIZE THE LOCAL GREEN'S FUNCTION Gloc^{x=M,<,R,\lmix}
-    G=zero
-    do ik=1,Lk
-       call neq_setup_initial_conditions(gk(ik),dgk(ik),selfHF(1),self,hk(ik),params)
-    enddo
-    call sum_kb_contour_gf(gk(:),wtk(:),g,params)
-    !
-    !INITIALIZE THE WEISS FIELD G0^{x=M,<,R,\lmix}
-    g0%iw = one/(one/g%iw + self%iw) !Dyson: G0^-1 = Gloc^-1 + Sigma
-    allocate(Rtau(0:Lf))
-    call fft_gf_iw2tau(g0%iw,Rtau(0:),params%beta)
-    call fft_extract_gtau(Rtau,g0%mats)
-    deallocate(Rtau)
-    g0%less(1,1) = -xi*g0%mats(L)
-    g0%ret(1,1)  = -xi
-    forall(i=0:L)g0%lmix(1,i)=-xi*g0%mats(L-i)
-    return
-  end subroutine neq_continue_equilibirum_normal
-
-
-  subroutine neq_continue_equilibirum_bethe(g0,dg0,g,selfHF,self,params,wband)
-    type(kb_contour_gf)                 :: g0
-    type(kb_contour_dgf)                :: dg0
-    type(kb_contour_gf)                 :: g
-    type(kb_contour_gf)                 :: self
-    complex(8)                          :: selfHF(:)
-    type(kb_contour_params)             :: params
-    real(8),optional                    :: wband
-    real(8)                             :: wband_
-    real(8)                             :: wm,res,ims
-    logical                             :: bool
-    integer                             :: i,j,k,ik,unit,len,N,L,Lf
-    complex(8)                          :: zeta
-    complex(8)                          :: Self_gtr
-    complex(8),allocatable,dimension(:) :: GxG0
-    real(8)                             :: Scoeff(2),Gcoeff(4)
-    wband_=1d0;if(present(wband))wband_=wband
-    if(.not.g0%status)stop "init_functions: g0 is not allocated"
-    if(.not.dg0%status)stop "init_functions: dg0 is not allocated"
-    if(.not.g%status)stop "init_functions: g is not allocated"
-    if(.not.self%status)stop "init_functions: self is not allocated"
-    if(.not.params%status)stop "init_functions: params is not allocated"
-    if(size(selfHF)/=params%Ntime)stop "init_functions: size(selfHF)!=Ntime"
-    !
-    N = params%Nt
-    L = params%Ntau
-    Lf= params%Niw
-    !
-    !INITIALIZE THE SELF-ENERGY SELF^{x=M,<,R,\lmix}
-    call read_equilibrium_sigma_normal(selfHF,self,params)            !<== get Sigma^{x=iw,tau,M,<,R,\lmix}
-    !
-    !INITIALIZE THE GREEN'S FUNCTION G^{x=M,<,R,\lmix}
-    do i=1,Lf
-       wm    = pi/beta*dble(2*i-1)
-       zeta  = xi*wm - Self%iw(i)
-       G%iw(i) = gfbethe(wm,zeta,wband)
-    enddo
-    !Gcoeff      = tail_coeff_glat(Ui,dens,xmu,hloc=0d0)
-    allocate(Rtau(0:Lf))
-    call fft_gf_iw2tau(G%iw,Rtau(0:),beta,Gcoeff)     !get G(tau)
-    call fft_extract_gtau(Rtau(0:),G%mats)
-    deallocate(Rtau)
-    G%ret(1,1)  = -xi                               !get G^R(0,0)=-xi
-    G%less(1,1) = -xi*G%mats(L)                  !get G^<(0,0)= xi*G^M(0-)
-    forall(i=0:L)G%lmix(1,i)=-xi*G%mats(L-i) !get G^\lmix(0,tau)=-xi*G(beta-tau>0)
-    !
-    !INITIALIZE THE WEISS FIELD G0^{x=M,<,R,\lmix}
-    g0%iw = one/(one/g%iw + self%iw) !Dyson: G0^-1 = Gloc^-1 + Sigma
-    allocate(Rtau(0:Lf))
-    call fft_gf_iw2tau(g0%iw,Rtau(0:),params%beta)
-    call fft_extract_gtau(Rtau,g0%mats)
-    deallocate(Rtau)
-    g0%less(1,1) = -xi*g0%mats(L)
-    g0%ret(1,1)  = -xi
-    forall(i=0:L)g0%lmix(1,i)=-xi*g0%mats(L-i)
-    !
-    !Derivatives d/dt G0:
-    allocate(GxG0(0:L))
-    !get d/dt G0^R = 0.d0
-    dG0%ret(1)  = zero
-    !get d/dt G0^< = -xi(-xi)int_0^beta G^\lmix * G0^\rmix
-    do k=0,L
-       GxG0(k)=G%lmix(1,k)*conjg(G0%lmix(1,L-k))
-    end do
-    dG0%less(1) = -xi*(-xi)*params%dtau*kb_trapz(GxG0(0:),0,L) 
-    !get d/dt G0^\lmix = -xi*int_0^beta G0^\lmix * G0^M
-    dG0%lmix(0:)= zero
-    do j=0,L
-       do k=0,j
-          GxG0(k)=G%lmix(1,k)*G0%mats(k+L-j)
-       end do
-       dG0%lmix(j)=dG0%lmix(j)+xi*params%dtau*kb_trapz(GxG0(0:),0,j)
-       do k=j,L
-          GxG0(k)=G%lmix(1,k)*G0%mats(k-j)
-       end do
-       dG0%lmix(j)=dG0%lmix(j)-xi*params%dtau*kb_trapz(GxG0(0:),j,L) 
-    enddo
-    deallocate(GxG0)
-    !
-    return
-  end subroutine neq_continue_equilibirum_bethe
-
-
-
-
-
-
-
-
-
-
-
-  !+-------------------------------------------------------------------+
-  !PURPOSE: setup initial conditions for k-resolved GF
-  !+-------------------------------------------------------------------+
-  subroutine neq_setup_initial_conditions(Gk,dGk,SelfHF,Self,Hk,params)
-    type(kb_contour_gf)                 :: Gk
-    type(kb_contour_dgf)                :: dGk
-    complex(8)                          :: SelfHF
-    type(kb_contour_gf)                 :: Self
-    real(8)                             :: Hk
-    type(kb_contour_params)             :: params
-    integer                             :: i,j,k,L,Lf
-    complex(8),allocatable,dimension(:) :: SxG
-    !
-    L = params%Ntau
-    Lf= params%Niw
-    !
-    do i=1,Lf
-       Gk%iw(i) = one/(xi*params%wm(i) - Hk - Self%iw(i))
-    enddo
-    !
-    allocate(Rtau(0:Lf))
-    call fft_gf_iw2tau(Gk%iw,Rtau(0:),beta) !get G_k(tau)
-    call fft_extract_gtau(Rtau,Gk%mats)     !
-    deallocate(Rtau)
-    Gk%less(1,1)  = -xi*Gk%mats(L)          !get G^<_k(0,0)= xi*G^M_k(0-)
-    Gk%ret(1,1)   = -xi                     !get G^R_k(0,0)=-xi
-    Gk%lmix(1,0:L)= -xi*Gk%mats(L:0:-1)     !get G^\lmix_k(0,tau)=xi*G_k(tau<0)=-xi*G_k(beta-tau>0)
-    !
-    !Derivatives
-    allocate(SxG(0:L))
-    !
-    !get d/dt G_k^R = -i e(k,0)G_k^R
-    dGk%ret(1)  = -xi*(Hk-SelfHF)*Gk%ret(1,1)
-    !
-    !get d/dt G_k^< = -i e(k,0)G_k^< -xi(-xi)int_0^beta S^\lmix*G_k^\rmix
-    do k=0,L
-       SxG(k)=self%lmix(1,k)*conjg(Gk%lmix(1,L-k))
-    end do
-    dGk%less(1) = -xi*(Hk-SelfHF)*Gk%less(1,1)-xi*(-xi)*params%dtau*kb_trapz(SxG(0:),0,L) 
-    !
-    !get d/dt G_k^\lmix = -xi*e(k,0)*G_k^\lmix - xi*int_0^beta G_k^\lmix*G_k^M
-    dGk%lmix(0:)= -xi*(Hk-SelfHF)*Gk%lmix(1,0:)
-    do j=0,L
-       do k=0,j
-          SxG(k)=self%lmix(1,k)*Gk%mats(k+L-j)
-       end do
-       dGk%lmix(j)=dGk%lmix(j)+xi*params%dtau*kb_trapz(SxG(0:),0,j)
-       do k=j,L
-          SxG(k)=self%lmix(1,k)*Gk%mats(k-j)
-       end do
-       dGk%lmix(j)=dGk%lmix(j)-xi*params%dtau*kb_trapz(SxG(0:),j,L) 
-    enddo
-  end subroutine neq_setup_initial_conditions
-
 
 
 
@@ -243,10 +39,274 @@ contains
   ! NORMAL SIGMA:
   ! # U_i n [with U_i = interactino strenght at equilibrium, n=density
   ! ....
-  ! ANOMALOUS SELF:
-  ! # U_i Delta [with U_i as before, Delta = U*phi, phi=<cc> order parameter.
-  ! ....
   !+-------------------------------------------------------------------+
+  subroutine read_equilibrium_sigma_normal(self,params)
+    type(kb_contour_sigma)           :: self
+    type(kb_contour_params)          :: params
+    real(8)                          :: tau
+    logical                          :: bool
+    complex(8)                       :: zeta
+    integer                          :: i,j,k,ik,unit,Len,N,L,Lf,Ltau
+    real(8)                          :: u_,dens
+    real(8),dimension(0:1)           :: Scoeff
+    real(8),allocatable,dimension(:) :: Stau !dummy function for FFT to tau
+    !
+    if(.not.self%status)  stop "read_equilibrium_sigma: sigma is not allocated"
+    if(.not.params%status)stop "read_equilibrium_sigma: params is not allocated"
+    !
+    N = params%Nt
+    L = params%Ntau
+    Lf= params%Niw
+    !
+    inquire(file=reg(sigma_file),exist=bool)
+    if(bool)then
+       write(*,"(A)")"read_equilibrium_sigma_normal: reading Sigma(tau) from file "//reg(sigma_file)
+       dens = read_header(reg(sigma_file))
+       Len  = file_length(reg(sigma_file))
+       Ltau = Len-1-1           !-1 for the header, -1 for the 0
+       if(Ltau < L)stop "read_equilibrium_sigma_normal error: Ltau < params%Ntau"
+       allocate(Stau(0:Ltau))
+       unit = free_unit()
+       open(unit,file=reg(sigma_file),status='old')
+       do i=0,Ltau
+          read(unit,*)tau,Stau(i)
+       enddo
+       close(unit)
+       call fft_extract_gtau(Stau(0:),Self%reg%mats(0:))       !<=== Get Sigma(tau)= xtract(tmp_selt(tau_))
+       self%hf(1) = Ui*(dens-0.5d0)                            !<=== Get Sigma_HF  = Re[Sigma(iw-->infty)]
+       Scoeff  = tail_coeff_sigma(Ui,dens)
+       call fft_sigma_tau2iw(Self%reg%iw,Stau(0:),beta,Scoeff) !<=== Get Sigma(iw) = fft(tmp_self(tau_))
+       deallocate(Stau)
+    else
+       write(*,"(A)")"read_equilibrium_sigma_normal: start from Hartree-Fock Sigma(iw)=Ui*(n-1/2)"
+       dens=0.5d0
+       self%hf(1)   = Ui*(dens-0.5d0)
+       self%reg%iw  = zero
+       self%reg%mats= zero
+    endif
+    self%reg%less(1,1)  = -xi*self%reg%mats(L)                     !OK
+    self%reg%ret(1,1)   =  xi*(self%reg%mats(0)+self%reg%mats(L))  !OK
+    self%reg%lmix(1,0:L)= -xi*self%reg%mats(L:0:-1)                !small errors near 0,beta
+  end subroutine read_equilibrium_sigma_normal
+
+
+
+
+  !+-------------------------------------------------------------------+
+  !PURPOSE: setup initial conditions for k-resolved GF
+  !+-------------------------------------------------------------------+
+  subroutine neq_setup_initial_conditions_normal(Gk,dGk,Self,Hk,params)
+    type(kb_contour_gf)                 :: Gk
+    type(kb_contour_dgf)                :: dGk
+    type(kb_contour_sigma)              :: Self
+    real(8)                             :: Hk
+    real(8)                             :: Hk_hf
+    type(kb_contour_params)             :: params
+    integer                             :: i,j,k,L,Lf
+    complex(8),allocatable,dimension(:) :: SxG
+    real(8),allocatable,dimension(:)    :: Stau !dummy function for FFT to tau
+    complex(8),allocatable,dimension(:) :: Siw  !dummy function in iw_n
+    !
+    L = params%Ntau
+    Lf= params%Niw
+    allocate(Siw(Lf),Stau(0:Lf))
+    allocate(SxG(0:L))
+    !
+    Siw   = self%reg%iw + self%hf(1)
+    Hk_hf = Hk - self%hf(1)
+    do i=1,Lf
+       Gk%iw(i) = one/(xi*params%wm(i) - Hk - Siw(i))
+    enddo
+    call fft_gf_iw2tau(Gk%iw,Stau(0:),beta) !get G_k(tau)
+    call fft_extract_gtau(Stau,Gk%mats)     !
+    Gk%less(1,1)  = -xi*Gk%mats(L)          !get G^<_k(0,0)= xi*G^M_k(0-)
+    Gk%ret(1,1)   = -xi                     !get G^R_k(0,0)=-xi
+    Gk%lmix(1,0:L)= -xi*Gk%mats(L:0:-1)     !get G^\lmix_k(0,tau)=xi*G_k(tau<0)=-xi*G_k(beta-tau>0)
+    !
+    !Derivatives
+    !get d/dt G_k^R = -i [e(k,0)-Sigma_HF(0)]G_k^R
+    dGk%ret(1)  = -xi*Hk_hf*Gk%ret(1,1)
+    !
+    !get d/dt G_k^< = -i [e(k,0)-Sigma_HF(0)]G_k^< -xi(-xi)int_0^beta S^\lmix*G_k^\rmix
+    SxG(0:)=zero
+    do k=0,L
+       SxG(k)=self%reg%lmix(1,k)*conjg(Gk%lmix(1,L-k))
+    end do
+    dGk%less(1) = -xi*Hk_hf*Gk%less(1,1)-xi*(-xi)*params%dtau*kb_trapz(SxG(0:),0,L) 
+    !
+    !get d/dt G_k^\lmix = -xi*[e(k,0)-Sigma_HF(0)]*G_k^\lmix - xi*int_0^beta G_k^\lmix*G_k^M
+    dGk%lmix(0:)= -xi*Hk_hf*Gk%lmix(1,0:)
+    do j=0,L
+       SxG(0:)=zero
+       do k=0,j
+          SxG(k)=Self%reg%lmix(1,k)*Gk%mats(k+L-j)
+       end do
+       dGk%lmix(j)=dGk%lmix(j)+xi*params%dtau*kb_trapz(SxG(0:),0,j)
+       SxG(0:)=zero
+       do k=j,L
+          SxG(k)=Self%reg%lmix(1,k)*Gk%mats(k-j)
+       end do
+       dGk%lmix(j)=dGk%lmix(j)-xi*params%dtau*kb_trapz(SxG(0:),j,L) 
+    enddo
+    !
+    deallocate(Siw,Stau,SxG)
+  end subroutine neq_setup_initial_conditions_normal
+
+
+
+
+
+
+
+  !+-------------------------------------------------------------------+
+  !PURPOSE: continue the NORMAL/SUPERC equilibrium to Keldysh contour
+  !+-------------------------------------------------------------------+
+  subroutine neq_continue_equilibirum_normal_lattice(g0,gk,dgk,g,self,Hk,Wtk,params)
+    type(kb_contour_gf)                 :: g0
+    type(kb_contour_gf)                 :: gk(:)
+    type(kb_contour_dgf)                :: dgk(size(gk))
+    type(kb_contour_gf)                 :: g
+    type(kb_contour_sigma)              :: self
+    real(8)                             :: Hk(size(gk)),Wtk(size(gk))
+    type(kb_contour_params)             :: params
+    logical                             :: bool
+    integer                             :: i,j,k,ik,unit,len,N,L,Lf,Lk
+    real(8),allocatable,dimension(:)    :: G0tau !dummy function for FFT to tau
+    complex(8),allocatable,dimension(:) :: Siw  !dummy function in iw_n
+    !
+    Lk=size(gk)
+    N = params%Nt
+    L = params%Ntau
+    Lf= params%Niw
+    allocate( Siw(Lf),G0tau(0:Lf) )
+    !
+    if(.not.g0%status)stop "init_functions: g0 is not allocated"
+    if(.not.g%status)stop "init_functions: g is not allocated"
+    if(.not.self%status)stop "init_functions: self is not allocated"
+    do ik=1,Lk
+       if(.not.gk(ik)%status)stop "init_functions: gk(ik) is not allocated"
+       if(.not.dgk(ik)%status)stop "init_functions: dgk(ik) is not allocated"
+    enddo
+    if(.not.params%status)stop "init_functions: params is not allocated"
+    !
+    !INITIALIZE THE SELF-ENERGY SELF^{x=M,<,R,\lmix}
+    call read_equilibrium_sigma_normal(self,params)            !<== get Sigma^{x=iw,tau,M,<,R,\lmix}
+    !
+    !INITIALIZE THE LOCAL GREEN'S FUNCTION Gloc^{x=M,<,R,\lmix}
+    g=zero
+    do ik=1,Lk
+       call neq_setup_initial_conditions_normal(gk(ik),dgk(ik),self,hk(ik),params)
+    enddo
+    call sum_kb_contour_gf(gk(:),wtk(:),g,params)
+    !
+    !INITIALIZE THE WEISS FIELD G0^{x=M,<,R,\lmix}
+    Siw   = self%reg%iw + self%hf(1)       !Sigma = Sigma_reg + SigmaHF
+    ! g0%iw = one/( one/g%iw + Siw )       !Dyson: G0^-1 = Gloc^-1 + Sigma
+    g0%iw = one/( one/g%iw + self%reg%iw ) !Dyson: tildeG0^-1 = Gloc^-1 + Sigma_reg = Gloc^-1 + Sigma - Sigma_HF
+    call fft_gf_iw2tau(g0%iw,G0tau(0:),params%beta)
+    call fft_extract_gtau(G0tau,g0%mats)
+    g0%less(1,1)  = -xi*g0%mats(L)
+    g0%ret(1,1)   = -xi
+    g0%lmix(1,0:L)= -xi*g0%mats(L:0:-1)
+    !
+    deallocate(G0tau,Siw)
+  end subroutine neq_continue_equilibirum_normal_lattice
+
+  subroutine neq_continue_equilibirum_normal_bethe(g0,dg0,g,self,params,wband)
+    type(kb_contour_gf)                 :: g0
+    type(kb_contour_dgf)                :: dg0
+    type(kb_contour_gf)                 :: g
+    type(kb_contour_sigma)              :: self
+    type(kb_contour_params)             :: params
+    real(8),optional                    :: wband
+    real(8)                             :: wband_
+    real(8)                             :: wm,res,ims
+    logical                             :: bool
+    integer                             :: i,j,k,ik,unit,len,N,L,Lf
+    complex(8)                          :: zeta
+    complex(8)                          :: Self_gtr
+    complex(8),allocatable,dimension(:) :: GxG0
+    real(8)                             :: Scoeff(2),Gcoeff(4)
+    real(8),allocatable,dimension(:)    :: Gtau
+    complex(8),allocatable,dimension(:) :: Siw
+    !
+    wband_=1d0;if(present(wband))wband_=wband
+    if(.not.g0%status)stop "init_functions: g0 is not allocated"
+    if(.not.dg0%status)stop "init_functions: dg0 is not allocated"
+    if(.not.g%status)stop "init_functions: g is not allocated"
+    if(.not.self%status)stop "init_functions: self is not allocated"
+    if(.not.params%status)stop "init_functions: params is not allocated"
+    !
+    N = params%Nt
+    L = params%Ntau
+    Lf= params%Niw
+    allocate( Siw(Lf), Gtau(0:L), GxG0(0:L) )
+    !
+    !INITIALIZE THE SELF-ENERGY SELF^{x=M,<,R,\lmix}
+    call read_equilibrium_sigma_normal(self,params)            !<== get Sigma^{x=iw,tau,M,<,R,\lmix}
+    !
+    !INITIALIZE THE GREEN'S FUNCTION G^{x=M,<,R,\lmix}
+    Siw = self%reg%iw + self%hf(1)
+    do i=1,Lf
+       wm    = pi/beta*dble(2*i-1)
+       zeta  = xi*wm - Siw(i)
+       G%iw(i) = gfbethe(wm,zeta,wband)
+    enddo
+    !Gcoeff      = tail_coeff_glat(Ui,dens,xmu,hloc=0d0)
+    call fft_gf_iw2tau(G%iw,Gtau(0:),beta,Gcoeff)     !get G(tau)
+    call fft_extract_gtau(Gtau,G%mats)
+    G%ret(1,1)   = -xi                !get G^R(0,0)=-xi
+    G%less(1,1)  = -xi*G%mats(L)      !get G^<(0,0)= xi*G^M(0-)
+    G%lmix(1,0:L)= -xi*G%mats(L:0:-1) !get G^\lmix(0,tau)=-xi*G(beta-tau>0)
+    !
+    !INITIALIZE THE WEISS FIELD G0^{x=M,<,R,\lmix}
+    g0%iw = one/(one/g%iw + self%reg%iw) !Dyson: tideG0^-1 = Gloc^-1 + Sigma_reg
+    call fft_gf_iw2tau(g0%iw,Gtau(0:),params%beta)
+    call fft_extract_gtau(Gtau,g0%mats)
+    g0%less(1,1)  = -xi*g0%mats(L)
+    g0%ret(1,1)   = -xi
+    g0%lmix(1,0:L)= -xi*g0%mats(L:0:-1)
+    !
+    !Derivatives d/dt G0:
+    !get d/dt G0^R = 0.d0
+    dG0%ret(1)  = zero
+    !get d/dt G0^< = -xi(-xi)int_0^beta G^\lmix * G0^\rmix
+    GxG0(0:)=zero
+    do k=0,L
+       GxG0(k)=G%lmix(1,k)*conjg(G0%lmix(1,L-k))
+    end do
+    dG0%less(1) = -xi*(-xi)*params%dtau*kb_trapz(GxG0(0:),0,L) 
+    !get d/dt G0^\lmix = -xi*int_0^beta G0^\lmix * G0^M
+    dG0%lmix(0:)= zero
+
+    do j=0,L
+       GxG0(0:)=zero
+       do k=0,j
+          GxG0(k)=G%lmix(1,k)*G0%mats(k+L-j)
+       end do
+       dG0%lmix(j)=dG0%lmix(j)+xi*params%dtau*kb_trapz(GxG0(0:),0,j)
+       GxG0(0:)=zero
+       do k=j,L
+          GxG0(k)=G%lmix(1,k)*G0%mats(k-j)
+       end do
+       dG0%lmix(j)=dG0%lmix(j)-xi*params%dtau*kb_trapz(GxG0(0:),j,L) 
+    enddo
+    !
+    deallocate(Siw,Gtau,GxG0)
+    return
+  end subroutine neq_continue_equilibirum_normal_bethe
+
+
+
+
+
+
+
+  !+-----------------------------------------------------------------------------+!
+  !PURPOSE: AUXILIARY ROUTINES:
+  !  - read_header     : read the header of the seed file for the Self-energy S(tau)
+  !  - fft_extract_gtau: extract a G(tau) from a dense to a sparse set.
+  !+-----------------------------------------------------------------------------+!
   function read_header(file)  result(obs)
     character(len=*) :: file
     integer          :: unit
@@ -261,66 +321,6 @@ contains
     endif
     write(*,"(4A)")"Header of the file:",reg(txtfy(u_))," ",reg(txtfy(obs))
   end function read_header
-
-  subroutine read_equilibrium_sigma_normal(selfHF,self,params)
-    complex(8)              :: selfHF(:)
-    type(kb_contour_gf)     :: self
-    type(kb_contour_params) :: params
-    real(8)                 :: tau,stau
-    logical                 :: bool
-    complex(8)              :: zeta
-    integer                 :: i,j,k,ik,unit,Len,N,L,Lf,Ltau
-    real(8)                 :: u_,dens
-    real(8),dimension(0:1)  :: Scoeff
-    !
-    if(.not.self%status)  stop "read_equilibrium_sigma: sigma is not allocated"
-    if(.not.params%status)stop "read_equilibrium_sigma: params is not allocated"
-    if(size(selfHF)/=params%Ntime)stop "read_equilibrium_sigma: size(selfHF)!=Ntime"
-    !
-    N = params%Nt
-    L = params%Ntau
-    Lf= params%Niw
-    !
-    selfHF=zero
-    !
-    inquire(file=reg(sigma_file),exist=bool)
-    if(bool)then
-       write(*,"(A)")"read_equilibrium_sigma_normal: reading Sigma(tau) from file "//reg(sigma_file)
-       dens = read_header(reg(sigma_file))
-       Len  = file_length(reg(sigma_file))
-       Ltau = Len-1-1           !-1 for the header, -1 for the 0
-       unit = free_unit()
-       open(unit,file=reg(sigma_file),status='old')
-       if(Ltau < L)stop "read_equilibrium_sigma_normal error: Ltau < params%Ntau"
-       allocate(Rtau(0:Ltau))
-       do i=0,Ltau
-          read(unit,*)tau,Rtau(i)
-       enddo
-       close(unit)
-       call fft_extract_gtau(Rtau(0:),Self%mats(0:))       !<=== Get Sigma(tau)= xtract(tmp_selt(tau_))
-       selfHF(1) = Ui*(dens-0.5d0)                          !<=== Get Sigma_HF  = Re[Sigma(iw-->infty)]
-       !get the matsubara freq. component to build Gloc and G0: 
-       Scoeff  = tail_coeff_sigma(Ui,dens)
-       call fft_sigma_tau2iw(Self%iw,Rtau(0:),beta,Scoeff) !<=== Get Sigma(iw) = fft(tmp_self(tau_))
-       self%iw = self%iw + selfHF(1)                       !<=== Sum back HF contribution: Sigma(iw)+Sigma_HF
-       deallocate(Rtau)
-       !
-    else
-       !
-       write(*,"(A)")"read_equilibrium_sigma_normal: start from Hartree-Fock Sigma(iw)=Ui*(n-1/2)"
-       dens=0.5d0
-       selfHF(1) = Ui*(dens-0.5d0)    !set self-energy to zero or whatever is the initial HF solution
-       self      = zero
-       !
-    endif
-    !
-    self%less(1,1) = -xi*self%mats(L)                     !OK
-    self%ret(1,1) =   xi*(self%mats(0)+self%mats(L))      !OK
-    forall(i=0:L)self%lmix(1,i)=-xi*self%mats(L-i)        !small errors near 0,beta
-    !
-  end subroutine read_equilibrium_sigma_normal
-
-
 
 
   subroutine fft_extract_gtau(g,gred)
@@ -341,81 +341,6 @@ contains
     enddo
   end subroutine fft_extract_gtau
 
-
-
-
-
-
-  ! subroutine read_equilibrium_weiss(g0,params,wband,Hk,Wtk)
-  !   type(kb_contour_gf)     :: g0
-  !   type(kb_contour_params) :: params
-  !   real(8),optional        :: Hk(:)
-  !   real(8),optional        :: Wtk(:)
-  !   real(8),optional        :: wband
-  !   real(8)                 :: wband_
-  !   real(8)                 :: wm,res,ims,mu
-  !   logical                 :: bool
-  !   complex(8)              :: zeta
-  !   integer                 :: i,j,k,ik,unit,len,N,L,Lf
-  !   real(8)                 :: Gcoeff(4)
-  !   wband_=1d0;if(present(wband))wband_=wband
-  !   !
-  !   if(.not.g0%status)stop "read_equilibrium_g0: g0 is not allocated"
-  !   if(.not.params%status)stop "read_equilibrium_g0: params is not allocated"
-  !   N = params%Nt
-  !   L = params%Ntau
-  !   Lf= params%Niw
-  !   !
-  !   !CHECK IF G0(IW) IS AVAILABLE OR START FROM THE NON-INTERACTING SOLUTION
-  !   inquire(file=trim(g0file),exist=bool)
-  !   if(bool)then
-  !      write(*,"(A)")"Reading initial G0(iw) from file"//trim(g0file)
-  !      unit = free_unit()
-  !      i = file_length(trim(g0file))-1
-  !      open(unit,file=trim(g0file),status='old')
-  !      if(i/=Lf)then
-  !         print*,"read_equilibrium_weiss: Liw in "//reg(g0file)//" different from the input:",Lf
-  !         print*,"read_equilibrium_weiss: check the header of the file xmu, <h>, <h**2>, <h_dc>"
-  !         stop
-  !      endif
-  !      read(unit,*)mu,h1,h2,hDC
-  !      if(mu/=xmu)then
-  !         print*,"read_equilibrium_weiss: mu in "//reg(g0file)//" different from the input:",xmu
-  !         stop
-  !      endif
-  !      write(*,"(A)")"Header of the file:",reg(txtfy(mu)),reg(txtfy(h1)),reg(txtfy(h2)),reg(txtfy(hDC))
-  !      do i=1,Lf
-  !         read(unit,*)wm,ims,res
-  !         g0%iw(i) = dcmplx(res,ims)
-  !      enddo
-  !      close(unit)
-  !   else
-  !      write(*,"(A)")"Start from Non-interacting Bethe-model G0(iw)"
-  !      mu=xmu ; h1=0d0 ; h2=0d0 ; hDC=0d0
-  !      write(*,"(5A)")"Header of the file:",reg(txtfy(mu)),reg(txtfy(h1)),reg(txtfy(h2)),reg(txtfy(hDC))
-  !      if(present(Hk))then
-  !         if(.not.present(Wtk))stop "read_equilibrium_weiss: Wtk not present"
-  !         do i=1,Lf
-  !            wm    = pi/beta*(2*i-1)
-  !            zeta  = xi*wm + xmu             
-  !            g0%iw(i) = sum_overk_zeta(zeta,Hk,Wtk)
-  !         enddo
-  !      else
-  !         do i=1,Lf
-  !            wm    = pi/beta*(2*i-1)
-  !            zeta  = xi*wm + xmu
-  !            g0%iw(i) = gfbethe(wm,zeta,wband_)
-  !         enddo
-  !      endif
-  !   endif
-  !   !
-  !   Gcoeff = tail_coeff_g0(Ui,h1,h2,hDC)
-  !   call fft_gf_iw2tau(g0%iw,g0%tau(0:),params%beta,Gcoeff)
-  !   call fft_extract_gtau(g0%tau,g0%mats)
-  !   g0%less(1,1) = -xi*g0%mats(L)
-  !   g0%ret(1,1)  = -xi
-  !   forall(i=0:L)g0%lmix(1,i)=-xi*g0%mats(L-i)
-  ! end subroutine read_equilibrium_weiss
 
 
 end module NEQ_EQUILIBRIUM

--- a/NEQ_INPUT_VARS.f90
+++ b/NEQ_INPUT_VARS.f90
@@ -83,7 +83,7 @@ contains
     call parse_input_variable(ncycles    , "NCYCLES" , inputFILE , default    =1 , comment="number of cycles in pulsed light signal ")
     call parse_input_variable(omega0     , "OMEGA0" , inputFILE , default     =acos(-1d0) , comment="parameter for the Oscilatting field and Pulsed light")
     call parse_input_variable(E1         , "E1" , inputFILE , default         =0d0 , comment="Electric field strenght for the AC+DC case (tune to resonate)")
-    call parse_input_variable(sigma_file    , "SIGMA_FILE" , inputFILE , default    ="Sigma.restart" , comment="File with Sigma(iw) + header")
+    call parse_input_variable(sigma_file , "SIGMA_FILE" , inputFILE , default    ="Sigma.restart" , comment="File with Sigma(iw) + header")
     call save_input_file(inputFILE)
     call sf_version(revision)
   end subroutine read_input_init

--- a/NEQ_IPT.f90
+++ b/NEQ_IPT.f90
@@ -2,50 +2,54 @@ module NEQ_IPT
   USE NEQ_CONTOUR
   USE NEQ_CONTOUR_GF
   USE NEQ_INPUT_VARS
+  USE NEQ_MEASURE
   implicit none
   private
 
-  public  :: neq_solve_hf
+  interface neq_solve_ipt
+     module procedure neq_solve_ipt_normal
+  end interface neq_solve_ipt
+
   public  :: neq_solve_ipt
 
 contains
 
 
   !+-------------------------------------------------------------------+
-  !PURPOSE  : Solve with the 2^nd IPT sigma functions
+  !PURPOSE: Solve with the 2^nd IPT sigma functions
+  !  - _normal: solve the 2nd order IPT for the normal (repulsive case)
+  ! at half-filling.
+  !TODO 1: work out the case with interaction in the form Unn.
+  !TODO 2: extend the routines to the non-half-filling.
   !+-------------------------------------------------------------------+
-  subroutine neq_solve_hf(G,SigmaHF,params)
-    type(kb_contour_gf)     :: G
-    complex(8),dimension(:) :: SigmaHF
-    type(kb_contour_params) :: params
-    real(8)                 :: Nt
-    integer                 :: N,L
-    !
-    N   = params%Nt                 !<== work with the ACTUAL size of the contour
-    L   = params%Ntau
-    !
-    if(size(SigmaHF)/=params%Ntime)stop "neq_solve_hf error: size(sigmaHF)!=Ntime"
-    nt = dimag(G%less(N,N))
-    SigmaHF = U*(nt-0.5d0)
-  end subroutine neq_solve_hf
-
-
-
-  !+-------------------------------------------------------------------+
-  !PURPOSE  : Solve with the 2^nd IPT sigma functions
-  !+-------------------------------------------------------------------+
-  subroutine neq_solve_ipt(G0,Sigma,params)
+  subroutine neq_solve_ipt_normal(G0,G,Sigma,params)
     type(kb_contour_gf)                   :: G0
-    type(kb_contour_gf)                   :: Sigma
+    type(kb_contour_gf)                   :: G
+    type(kb_contour_sigma)                :: Sigma
     type(kb_contour_params)               :: params
     integer                               :: N,L
-    complex(8),dimension(:,:),allocatable :: G0_gtr,Sigma_gtr,G0_rmix
+    complex(8),dimension(:,:),allocatable :: G0_gtr,G0_rmix,Sigma_reg_gtr
+    real(8)                               :: dens
     integer                               :: i,j,itau
     !
     N   = params%Nt                 !<== work with the ACTUAL size of the contour
     L   = params%Ntau
     !
-    allocate(G0_gtr(N,N),Sigma_gtr(N,N),G0_rmix(0:L,N))
+    !<DEBUG add test on G0,G,Sigma
+    !
+    !>DEBUG
+    !
+    !Get the HF contribution:
+    ! in this formulation this quantity is zero
+    ! because is [or it should be] n=0.5, while Sigma_HF=U*(n-0.5.
+    ! In the future we may want to implement something where the HF 
+    ! contribution is actually evaluated, either because n!=0.5 or
+    ! interaction is such that this term is of the form Sigma_HF=U*n
+    dens = measure_dens(g,params)
+    Sigma%hf(N) = zero          !U*(dens-0.5d0)
+    !
+    !Get the Regular contribution:
+    allocate( G0_gtr(N,N), G0_rmix(0:L,N), Sigma_reg_gtr(N,N) )
     do j=1,N
        G0_gtr(N,j)=G0%less(N,j)+G0%ret(N,j)
     end do
@@ -55,23 +59,22 @@ contains
     do j=0,L
        G0_rmix(j,N)  = conjg(G0%lmix(N,L-j))
     enddo
-
+    !
     !Vertical edge
     do j=1,N
-       Sigma%less(N,j)= U*U*G0%less(N,j)*G0_gtr(j,N)*G0%less(N,j)
-       Sigma_gtr(N,j) = U*U*G0_gtr(N,j)*G0%less(j,N)*G0_gtr(N,j)
+       Sigma%reg%less(N,j)= U*U*G0%less(N,j)*G0_gtr(j,N)*G0%less(N,j)
+       Sigma_reg_gtr(N,j) = U*U*G0_gtr(N,j)*G0%less(j,N)*G0_gtr(N,j)
     end do
     !Horizontal edge
     do i=1,N-1
-       Sigma%less(i,N)= U*U*G0%less(i,N)*G0_gtr(N,i)*G0%less(i,N)
-       Sigma_gtr(i,N) = U*U*G0_gtr(i,N)*G0%less(N,i)*G0_gtr(i,N)
+       Sigma%reg%less(i,N)= U*U*G0%less(i,N)*G0_gtr(N,i)*G0%less(i,N)
+       Sigma_reg_gtr(i,N) = U*U*G0_gtr(i,N)*G0%less(N,i)*G0_gtr(i,N)
     end do
     !Imaginary time edge:
-    forall(i=0:L)Sigma%lmix(N,i)  = U*Ui*G0%lmix(N,i)*G0_rmix(i,N)*G0%lmix(N,i)
-    forall(j=1:N)Sigma%ret(N,j) = Sigma_gtr(N,j) - Sigma%less(N,j)
-    !
-  end subroutine neq_solve_ipt
+    forall(i=0:L)Sigma%reg%lmix(N,i) = U*Ui*G0%lmix(N,i)*G0_rmix(i,N)*G0%lmix(N,i)
+    forall(j=1:N)Sigma%reg%ret(N,j)    = Sigma_reg_gtr(N,j) - Sigma%reg%less(N,j)
 
+  end subroutine neq_solve_ipt_normal
 
 
 

--- a/neq_contour_gf_add.f90
+++ b/neq_contour_gf_add.f90
@@ -1,0 +1,123 @@
+!C(t,t')=A(t,t') + B(t,t'), with t=t_max && t'=0,t_max
+!t_max_index==N
+subroutine add_kb_contour_gf_simple(A,B,C,params)
+  type(kb_contour_gf)     :: A,B,C
+  type(kb_contour_params) :: params
+  integer                 :: N,L
+  logical                 :: checkA,checkB,checkC
+  N   = params%Ntime   !<== work with the TOTAL size of the contour
+  L   = params%Ntau
+  if(  (.not.A%status).OR.&
+       (.not.B%status).OR.&
+       (.not.C%status))stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
+  checkA=check_dimension_kb_contour(A,N,L) 
+  checkB=check_dimension_kb_contour(B,N,L)
+  checkC=check_dimension_kb_contour(C,N,L)
+  !
+  C%less(:,:) = A%less(:,:) + B%less(:,:)
+  C%ret(:,:)  = A%ret(:,:)  + B%ret(:,:)
+  C%lmix(:,0:)= A%lmix(:,0:)+ B%lmix(:,0:)
+  C%mats(0:)  = A%mats(0:)  + B%mats(0:)
+  C%iw(:)     = A%iw(:)     + B%iw(:)
+end subroutine  add_kb_contour_gf_simple
+!
+subroutine add_kb_contour_gf_recursive(A,C,params)
+  type(kb_contour_gf)     :: A(:)
+  type(kb_contour_gf)     :: C
+  type(kb_contour_params) :: params
+  integer                 :: i,Na,N,L
+  logical                 :: checkA,checkC
+  !
+  Na=size(A)
+  N   = params%Ntime    !<== work with the TOTAL size of the contour
+  L   = params%Ntau
+  !
+  do i=1,Na
+     if(  (.not.A(i)%status) )stop "contour_gf/add_kb_contour_gf: A(i) not allocated"
+  enddo
+  if(  (.not.C%status) )stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
+  do i=1,Na
+     checkA=check_dimension_kb_contour(A(i),N,L) 
+  enddo
+  checkC=check_dimension_kb_contour(C,N,L)
+  !
+  C=zero
+  do i=1,Na
+     C%less(:,:) = C%less(:,:) + A(i)%less(:,:)
+     C%ret(:,:)  = C%ret(:,:)  + A(i)%ret(:,:)
+     C%lmix(:,0:)= C%lmix(:,0:)+ A(i)%lmix(:,0:)
+     C%mats(0:)  = C%mats(0:)  + A(i)%mats(0:)
+     C%iw(:)     = C%iw(:)     + A(i)%iw(:)
+  enddo
+end subroutine  add_kb_contour_gf_recursive
+
+subroutine add_kb_contour_gf_delta_d(A,B,C,params)
+  type(kb_contour_gf)     :: A,C
+  real(8),dimension(:)    :: B
+  type(kb_contour_params) :: params
+  integer                 :: N,L,i
+  logical                 :: checkA,checkC
+  !
+  N   = params%Ntime
+  L   = params%Ntau
+  !
+  if(  (.not.A%status).OR.&
+       (.not.C%status))stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
+  checkA=check_dimension_kb_contour(A,N,L) 
+  checkC=check_dimension_kb_contour(C,N,L)
+  !
+  if(size(B)<N)stop "contour_gf/add_kb_contour_gf: size(B) < N"
+  !
+  C = A
+  do i=1,N
+     C%ret(i,i) = C%ret(i,i) + B(i)
+  enddo
+  C%mats(0) = C%mats(0) + B(1)
+end subroutine  add_kb_contour_gf_delta_d
+
+subroutine add_kb_contour_gf_delta_c(A,B,C,params)
+  type(kb_contour_gf)     :: A,C
+  complex(8),dimension(:) :: B
+  type(kb_contour_params) :: params
+  integer                 :: N,L,i
+  logical                 :: checkA,checkC
+  !
+  N   = params%Ntime
+  L   = params%Ntau
+  !
+  if(  (.not.A%status).OR.&
+       (.not.C%status))stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
+  checkA=check_dimension_kb_contour(A,N,L) 
+  checkC=check_dimension_kb_contour(C,N,L)
+  !
+  if(size(B)<N)stop "contour_gf/add_kb_contour_gf: size(B) < N"
+  !
+  C = A
+  do i=1,N
+     C%ret(i,i) = C%ret(i,i) + B(i)
+  enddo
+  C%mats(0) = C%mats(0) + B(1)
+end subroutine  add_kb_contour_gf_delta_c
+
+
+
+
+subroutine add_kb_contour_dgf(A,B,C,params)
+  type(kb_contour_dgf)    :: A,B,C
+  type(kb_contour_params) :: params
+  integer                 :: N,L
+  logical                 :: checkA,checkB,checkC
+  if(  (.not.A%status).OR.&
+       (.not.B%status).OR.&
+       (.not.C%status))stop "contour_gf/add_kb_contour_gf: A,B,C not allocated"
+  N   = params%Nt                 !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  !
+  checkA=check_dimension_kb_contour(A,N,L)
+  checkB=check_dimension_kb_contour(B,N,L)
+  checkC=check_dimension_kb_contour(C,N,L)
+  !
+  C%less(:) = A%less(:) + B%less(:)
+  C%ret(:)  = A%ret(:)  + B%ret(:)  
+  C%lmix(0:)= A%lmix(0:)+ B%lmix(0:)
+end subroutine add_kb_contour_dgf

--- a/neq_contour_gf_allocate.f90
+++ b/neq_contour_gf_allocate.f90
@@ -1,0 +1,78 @@
+subroutine allocate_kb_contour_gf_main(G,params)
+  type(kb_contour_gf)     :: G
+  type(kb_contour_params) :: params
+  integer                 :: i,j,N,L,Lf
+  if(allocated(G%less))deallocate(G%less)
+  if(allocated(G%ret)) deallocate(G%ret)
+  if(allocated(G%lmix))deallocate(G%lmix)
+  if(allocated(G%mats))deallocate(G%mats)
+  if(allocated(G%iw))deallocate(G%iw)
+  N = params%Ntime            !<== allocate at maximum time
+  L = params%Ntau
+  Lf= params%Niw
+  allocate(G%less(N,N))  ; G%less=zero
+  allocate(G%ret(N,N))   ; G%ret=zero
+  allocate(G%lmix(N,0:L)); G%lmix=zero
+  allocate(G%mats(0:L))  ; G%mats=0d0
+  allocate(G%iw(Lf))     ; G%iw=zero
+  G%status=.true.
+end subroutine allocate_kb_contour_gf_main
+!
+subroutine allocate_kb_contour_sigma_main(S,params)
+  type(kb_contour_sigma)  :: S
+  type(kb_contour_params) :: params
+  integer                 :: N
+  if(S%status)call deallocate_kb_contour_sigma(S)
+  N = params%Ntime              !<== allocate at maximum time
+  call allocate_kb_contour_gf_main(S%reg,params)
+  allocate(S%hf(N))
+  S%status=.true.
+end subroutine allocate_kb_contour_sigma_main
+!
+subroutine allocate_kb_contour_dgf_main(dG,params,wgtr)
+  type(kb_contour_dgf)    :: dG
+  type(kb_contour_params) :: params
+  integer                 :: i,j,N,L
+  logical,optional        :: wgtr
+  if(allocated(dG%less))deallocate(dG%less)
+  if(allocated(dG%ret)) deallocate(dG%ret)
+  if(allocated(dG%lmix))deallocate(dG%lmix)
+  N=params%Ntime           !<== allocate at maximum time
+  L=params%Ntau
+  allocate(dG%less(N))  ; dG%less=zero
+  allocate(dG%ret(N))   ; dG%ret=zero
+  allocate(dG%lmix(0:L)); dG%lmix=zero
+  if(present(wgtr).AND.wgtr)then
+     allocate(dG%gtr(N))
+     dG%gtr=zero
+  endif
+  dG%status=.true.
+end subroutine allocate_kb_contour_dgf_main
+
+
+
+
+
+! DEALLOCATE
+subroutine deallocate_kb_contour_gf_main(G)
+  type(kb_contour_gf) :: G
+  if(.not.G%status)stop "contour_gf/deallocate_kb_contour_gf: G not allocated"
+  deallocate(G%less,G%ret,G%lmix,G%mats,G%iw)
+  G%status=.false.
+end subroutine deallocate_kb_contour_gf_main
+!
+subroutine deallocate_kb_contour_sigma_main(S)
+  type(kb_contour_sigma) :: S
+  if(.not.S%status)stop "contour_gf/deallocate_kb_contour_sigma: S not allocated"
+  if(S%reg%status)call deallocate_kb_contour_gf_main(S%reg)
+  if(allocated(S%hf)) deallocate(S%hf)
+  S%status=.false.
+end subroutine deallocate_kb_contour_sigma_main
+!
+subroutine deallocate_kb_contour_dgf_main(dG)
+  type(kb_contour_dgf) :: dG
+  if(.not.dG%status)stop "contour_gf/deallocate_kb_contour_dgf: dG not allocated"
+  deallocate(dG%less,dG%ret,dG%lmix)
+  if(allocated(dG%gtr))deallocate(dG%gtr)
+  dG%status=.false.
+end subroutine deallocate_kb_contour_dgf_main

--- a/neq_contour_gf_convolute.f90
+++ b/neq_contour_gf_convolute.f90
@@ -1,0 +1,605 @@
+!C(t,t')=(A*B)(t,t'), with t=t_max && t'=0,t_max ; t_max_index==N
+subroutine convolute_kb_contour_gf_gf(A,B,C,params,dcoeff,ccoeff)
+  type(kb_contour_gf)                 :: A,B,C
+  type(kb_contour_params)             :: params
+  real(8),optional                    :: dcoeff
+  complex(8),optional                 :: ccoeff
+  integer                             :: N,L
+  real(8)                             :: dt,dtau
+  complex(8),dimension(:),allocatable :: AxB    
+  integer                             :: i,j,k,itau,jtau
+  logical                             :: checkA,checkB,checkC
+  !
+  N   = params%Nt      !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  dt  = params%dt
+  dtau= params%dtau
+  !
+  if(N==1) stop "convolute_kb_contour_gf_gf error: called with N=1"
+  if(  (.not.A%status).OR.&
+       (.not.B%status).OR.&
+       (.not.C%status))stop "contour_gf/convolute_kb_contour_gf: A,B,C not allocated"
+  checkA=check_dimension_kb_contour(A,params%Ntime,L) 
+  checkB=check_dimension_kb_contour(B,params%Ntime,L)
+  checkC=check_dimension_kb_contour(C,params%Ntime,L)
+  !
+  allocate(AxB(0:max(L,N)))
+  !
+  !Ret. component
+  !C^R(t,t')=\int_{t'}^t ds A^R(t,s)*B^R(s,t')
+  C%ret(N,1:N)=zero
+  do j=1,N           !for all t' in 0:t_max
+     AxB(0:)  = zero !AxB should be set to zero before integration
+     do k=j,N        !store the convolution between t'{=j} and t{=N}
+        AxB(k) = A%ret(N,k)*B%ret(k,j)
+     enddo
+     C%ret(n,j) = C%ret(n,j) + dt*kb_trapz(AxB(0:),j,N)
+  enddo
+  !
+  !Lmix. component
+  !C^\lmix(t,tau')=\int_0^{beta} ds A^\lmix(t,s)*B^M(s,tau')
+  !                  +\int_0^{t} ds A^R(t,s)*B^\lmix(s,tau')
+  !               = I1 + I2
+  C%lmix(N,0:L)=zero
+  do jtau=0,L
+     !I1:
+     AxB(0:) = zero
+     do k=0,jtau
+        AxB(k)=A%lmix(N,k)*B%mats(L+k-jtau)
+     end do
+     C%lmix(N,jtau)=C%lmix(N,jtau)-dtau*kb_trapz(AxB(0:),0,jtau)
+     do k=jtau,L
+        AxB(k)=A%lmix(N,k)*B%mats(k-jtau)
+     end do
+     C%lmix(n,jtau)=C%lmix(n,jtau)+dtau*kb_trapz(AxB(0:),jtau,L)
+     !I2:
+     AxB(0:) = zero
+     do k=1,N
+        AxB(k) = A%ret(N,k)*B%lmix(k,jtau)
+     enddo
+     C%lmix(N,jtau) = C%lmix(N,jtau) + dt*kb_trapz(AxB(0:),1,N)
+  enddo
+  !
+  !Less component
+  !C^<(t,t')=-i\int_0^{beta} ds A^\lmix(t,s)*B^\rmix(s,t')
+  !             +\int_0^{t'} ds A^<(t,s)*B^A(s,t')
+  !             +\int_0^{t} ds A^R(t,s)*B^<(s,t')
+  ! (t,t')=>(N,j) <==> Vertical side, with tip (j=1,N) !!no tip (j=1,N-1)
+  do j=1,N                      !-1
+     C%less(N,j)=zero
+     do k=0,L
+        AxB(k)=A%lmix(N,k)*get_rmix(B,k,j,L)
+     end do
+     C%less(N,j)=C%less(N,j)-xi*dtau*kb_trapz(AxB(0:),0,L)
+     do k=1,j
+        AxB(k)=A%less(N,k)*get_adv(B,k,j)
+     end do
+     C%less(N,j)=C%less(N,j)+dt*kb_trapz(AxB(0:),1,j)
+     do k=1,N
+        AxB(k)=A%ret(N,k)*B%less(k,j)
+     end do
+     C%less(N,j)=C%less(N,j)+dt*kb_trapz(AxB(0:),1,N)
+  end do
+  !
+  ! (t,t`)=>(i,N) <==> Horizontal side, w/ no tip (i=1,N-1)
+  do i=1,N-1
+     C%less(i,N)=zero
+  enddo
+  ! do i=1,N-1
+  !    C%less(i,N)=zero
+  !    do k=0,L
+  !       !         AxB(k)=A%lmix(i,k)*conjg(B%lmix(n,L-k))
+  !       AxB(k)=A%lmix(i,k)*get_rmix(B,k,N,L)
+  !    end do
+  !    C%less(i,N)=C%less(i,N)-xi*dtau*kb_trapz(AxB(0:),0,L)
+  !    !
+  !    do k=1,N
+  !       !         AxB(k)=A%less(i,k)*conjg(B%ret(N,k))
+  !       AxB(k)=A%less(i,k)*get_adv(B,k,N)
+  !    end do
+  !    C%less(i,N)=C%less(i,N)+dt*kb_trapz(AxB(0:),1,N)
+  !    !
+  !    do k=1,i
+  !       AxB(k)=A%ret(i,k)*B%less(k,N)
+  !    end do
+  !    C%less(i,N)=C%less(i,N)+dt*kb_trapz(AxB(0:),1,i)
+  ! end do
+  !    
+  if(present(dcoeff))then
+     C%lmix(N,0:L) = dcoeff*C%lmix(N,0:L)
+     C%less(N,1:N-1)=dcoeff*C%less(N,1:N-1)
+     C%less(1:N,N)=dcoeff*C%less(1:N,N)
+     C%ret(N,1:N)=dcoeff*C%ret(N,1:N)
+  endif
+  if(present(ccoeff))then
+     C%lmix(N,0:L) = ccoeff*C%lmix(N,0:L)
+     C%less(N,1:N-1)=ccoeff*C%less(N,1:N-1)
+     C%less(1:N,N)=ccoeff*C%less(1:N,N)
+     C%ret(N,1:N)=ccoeff*C%ret(N,1:N)
+  endif
+  deallocate(AxB)
+end subroutine convolute_kb_contour_gf_gf
+
+
+!C(t,t')=[A*(Bhf*delta + Breg)](t,t'), with t=t_max && t'=0,t_max ; t_max_index==N
+subroutine convolute_kb_contour_gf_sigma(A,B,C,params,dcoeff,ccoeff)
+  type(kb_contour_gf)                 :: A
+  type(kb_contour_sigma)              :: B
+  type(kb_contour_gf)                 :: C
+  type(kb_contour_params)             :: params
+  real(8),optional                    :: dcoeff
+  complex(8),optional                 :: ccoeff
+  integer                             :: N,L
+  real(8)                             :: dt,dtau
+  complex(8),dimension(:),allocatable :: AxB    
+  integer                             :: i,j,k,itau,jtau
+  logical                             :: checkA,checkB,checkC
+  !
+  N   = params%Nt      !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  dt  = params%dt
+  dtau= params%dtau
+  !
+  if(N==1) stop "convolute_kb_contour_gf_sigma error: called with N=1"
+  if(  (.not.A%status).OR.&
+       (.not.B%status).OR.&
+       (.not.C%status))stop "contour_gf/convolute_kb_contour_gf: A,B,C not allocated"
+  checkA=check_dimension_kb_contour(A,params) 
+  checkB=check_dimension_kb_contour(B,params)
+  checkC=check_dimension_kb_contour(C,params)
+  !
+  allocate(AxB(0:max(L,N)))
+  !
+  !Ret. component
+  !C^R(t,t')=A^R(t,t')*Bhf(t') + \int_{t'}^t ds A^R(t,s)*Breg^R(s,t')
+  C%ret(N,1:N)=zero
+  do j=1,N
+     C%ret(N,j) = A%ret(N,j)*B%hf(j)
+     AxB(0:)=zero
+     do k=j,N
+        AxB(k) = A%ret(N,k)*B%reg%ret(k,j)
+     enddo
+     C%ret(N,j) = C%ret(N,j) + dt*kb_trapz(AxB(0:),j,N)
+  enddo
+  !
+  !Lmix. component
+  !C^\lmix(t,tau')= A^\lmix(t,tau')*Bhf(0+) +
+  !                 \int_0^{beta} ds A^\lmix(t,s)*Breg^M(s,tau') + 
+  !                 \int_0^{t} ds A^R(t,s)*Breg^\lmix(s,tau') 
+  !               = A^\lmix*Bhf + I1 + I2
+  C%lmix(N,0:L)=zero
+  do jtau=0,L
+     !A^\lmix*Bhf:
+     C%lmix(N,jtau) = A%lmix(N,jtau)*B%hf(1)
+     !I1:
+     AxB(0:)=zero
+     do k=0,jtau
+        AxB(k)=A%lmix(N,k)*B%reg%mats(L+k-jtau)
+     end do
+     C%lmix(N,jtau)=C%lmix(N,jtau)-dtau*kb_trapz(AxB(0:),0,jtau)
+     AxB(0:)=zero
+     do k=jtau,L
+        AxB(k)=A%lmix(N,k)*B%reg%mats(k-jtau)
+     end do
+     C%lmix(N,jtau)=C%lmix(N,jtau)+dtau*kb_trapz(AxB(0:),jtau,L)
+     !I2:
+     AxB(0:)=zero
+     do k=1,N
+        AxB(k) = A%ret(N,k)*B%reg%lmix(k,jtau)
+     enddo
+     C%lmix(N,jtau) = C%lmix(N,jtau) + dt*kb_trapz(AxB(0:),1,N)
+  enddo
+  !
+  !Less component
+  !C^<(t,t') =  A^<(t,t')*conjg(Bhf(t'))
+  !            -i\int_0^{beta} ds A^\lmix(t,s)*Breg^\rmix(s,t')
+  !            + \int_0^{t'} ds A^<(t,s)*Breg^A(s,t')
+  !            + \int_0^{t} ds A^R(t,s)*Breg^<(s,t')
+  !          =  A^<*Bhf* + I1 + I2 + I3
+  ! (t,t')=>(N,j) <==> Vertical side, with tip (j=1,N)
+  C%less(N,1:N)=zero
+  do j=1,N
+     !A^<*Bhf*:
+     C%less(N,j)=A%less(N,j)*conjg(B%hf(j))
+     !I1:
+     AxB(0:)=zero
+     do k=0,L
+        AxB(k)=A%lmix(N,k)*get_rmix(B%reg,k,j,L)
+     end do
+     C%less(N,j)=C%less(N,j)-xi*dtau*kb_trapz(AxB(0:),0,L)
+     !I2:
+     AxB(0:)=zero
+     do k=1,j
+        AxB(k)=A%less(N,k)*get_adv(B%reg,k,j)
+     end do
+     C%less(N,j)=C%less(N,j)+dt*kb_trapz(AxB(0:),1,j)
+     !I3:
+     AxB(0:)=zero
+     do k=1,N
+        AxB(k)=A%ret(N,k)*B%reg%less(k,j)
+     end do
+     C%less(N,j)=C%less(N,j)+dt*kb_trapz(AxB(0:),1,N)
+  end do
+  !
+  ! (t,t`)=>(i,N) <==> Horizontal side, w/ no tip (i=1,N-1)
+  C%less(1:N-1,N)=zero
+  !    
+  if(present(dcoeff))then
+     C%lmix(N,0:L) = dcoeff*C%lmix(N,0:L)
+     C%less(N,1:N-1)=dcoeff*C%less(N,1:N-1)
+     C%less(1:N,N)=dcoeff*C%less(1:N,N)
+     C%ret(N,1:N)=dcoeff*C%ret(N,1:N)
+  endif
+  if(present(ccoeff))then
+     C%lmix(N,0:L) = ccoeff*C%lmix(N,0:L)
+     C%less(N,1:N-1)=ccoeff*C%less(N,1:N-1)
+     C%less(1:N,N)=ccoeff*C%less(1:N,N)
+     C%ret(N,1:N)=ccoeff*C%ret(N,1:N)
+  endif
+  deallocate(AxB)
+end subroutine convolute_kb_contour_gf_sigma
+
+
+!C(t,t')=[(Ahf*delta + Areg)*B](t,t'), with t=t_max && t'=0,t_max ; t_max_index==N
+subroutine convolute_kb_contour_sigma_gf(A,B,C,params,dcoeff,ccoeff)
+  type(kb_contour_sigma)              :: A
+  type(kb_contour_gf)                 :: B
+  type(kb_contour_gf)                 :: C
+  type(kb_contour_params)             :: params
+  real(8),optional                    :: dcoeff
+  complex(8),optional                 :: ccoeff
+  integer                             :: N,L
+  real(8)                             :: dt,dtau
+  complex(8),dimension(:),allocatable :: AxB    
+  integer                             :: i,j,k,itau,jtau
+  logical                             :: checkA,checkB,checkC
+  !
+  N   = params%Nt      !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  dt  = params%dt
+  dtau= params%dtau
+  !
+  if(N==1) stop "convolute_kb_contour_sigma_gf error: called with N=1"
+  if(  (.not.A%status).OR.&
+       (.not.B%status).OR.&
+       (.not.C%status))stop "contour_gf/convolute_kb_contour_gf: A,B,C not allocated"
+  checkA=check_dimension_kb_contour(A,params) 
+  checkB=check_dimension_kb_contour(B,params)
+  checkC=check_dimension_kb_contour(C,params)
+  !
+  allocate(AxB(0:max(L,N)))
+  !
+  !Ret. component
+  !C^R(t,t')=Ahf(t)*B^R(t,t') + \int_{t'}^t ds Areg^R(t,s)*B ^R(s,t')
+  C%ret(N,1:N)=zero
+  do j=1,N
+     C%ret(N,j) = A%hf(N)*B%ret(N,j)
+     AxB(0:)=zero
+     do k=j,N
+        AxB(k) = A%reg%ret(N,k)*B%ret(k,j)
+     enddo
+     C%ret(N,j) = C%ret(N,j) + dt*kb_trapz(AxB(0:),j,N)
+  enddo
+  !
+  !Lmix. component
+  !C^\lmix(t,tau')= Ahf(t)*B^\lmix(t,tau') +
+  !                 \int_0^{beta} ds A^\lmix(t,s)*Breg^M(s,tau') + 
+  !                 \int_0^{t} ds A^R(t,s)*Breg^\lmix(s,tau') 
+  !               = Ahf*B^\lmix + I1 + I2
+  C%lmix(N,0:L)=zero
+  do jtau=0,L
+     !Ahf*B^\lmix:
+     C%lmix(N,jtau) = A%hf(N)*B%lmix(N,jtau)
+     !I1: take care of the sign of (tau-tau').
+     AxB(0:) = zero
+     do k=0,jtau
+        AxB(k)=A%reg%lmix(N,k)*B%mats(L+k-jtau)
+     end do
+     C%lmix(N,jtau)=C%lmix(N,jtau)-dtau*kb_trapz(AxB(0:),0,jtau)
+     AxB(0:) = zero
+     do k=jtau,L
+        AxB(k)=A%reg%lmix(N,k)*B%mats(k-jtau)
+     end do
+     C%lmix(N,jtau)=C%lmix(N,jtau)+dtau*kb_trapz(AxB(0:),jtau,L)
+     !I2:
+     AxB(0:) = zero
+     do k=1,N
+        AxB(k) = A%reg%ret(N,k)*B%lmix(k,jtau)
+     enddo
+     C%lmix(N,jtau) = C%lmix(N,jtau) + dt*kb_trapz(AxB(0:),1,N)
+  enddo
+  !
+  !Less component
+  !C^<(t,t') =  Ahf(t)*B^<(t,t')
+  !            -i\int_0^{beta} ds A^\lmix(t,s)*Breg^\rmix(s,t')
+  !            + \int_0^{t'} ds A^<(t,s)*Breg^A(s,t')
+  !            + \int_0^{t} ds A^R(t,s)*Breg^<(s,t')
+  !          = Ahf*B^< + I1 + I2 + I3
+  ! (t,t')=>(N,j) <==> Vertical side, with tip (j=1,N)
+  C%less(N,1:N)=zero
+  do j=1,N
+     !Ahf*B^<:
+     C%less(N,j)=A%hf(N)*B%less(N,j)
+     !I1:
+     AxB(0:) = zero
+     do k=0,L
+        AxB(k)=A%reg%lmix(N,k)*get_rmix(B,k,j,L)
+     end do
+     C%less(N,j)=C%less(N,j)-xi*dtau*kb_trapz(AxB(0:),0,L)
+     !I2:
+     AxB(0:) = zero
+     do k=1,j
+        AxB(k)=A%reg%less(N,k)*get_adv(B,k,j)
+     end do
+     C%less(N,j)=C%less(N,j)+dt*kb_trapz(AxB(0:),1,j)
+     !I3:
+     AxB(0:) = zero
+     do k=1,N
+        AxB(k)=A%reg%ret(N,k)*B%less(k,j)
+     end do
+     C%less(N,j)=C%less(N,j)+dt*kb_trapz(AxB(0:),1,N)
+  end do
+  !
+  ! (t,t`)=>(i,N) <==> Horizontal side, w/ no tip (i=1,N-1)
+  C%less(1:N-1,N)=zero
+  !    
+  if(present(dcoeff))then
+     C%lmix(N,0:L) = dcoeff*C%lmix(N,0:L)
+     C%less(N,1:N-1)=dcoeff*C%less(N,1:N-1)
+     C%less(1:N,N)=dcoeff*C%less(1:N,N)
+     C%ret(N,1:N)=dcoeff*C%ret(N,1:N)
+  endif
+  if(present(ccoeff))then
+     C%lmix(N,0:L) = ccoeff*C%lmix(N,0:L)
+     C%less(N,1:N-1)=ccoeff*C%less(N,1:N-1)
+     C%less(1:N,N)=ccoeff*C%less(1:N,N)
+     C%ret(N,1:N)=ccoeff*C%ret(N,1:N)
+  endif
+  deallocate(AxB)
+end subroutine convolute_kb_contour_sigma_gf
+
+
+!C(t,t') = (a_1*a_2*...*a_n)(t,t')with t=t_max && t'=0,t_max; t_max_index==N
+! a_i = contour_gf forall i=1,...,n
+subroutine convolute_kb_contour_gf_gf_recursive(A,C,params,dcoeff,ccoeff)
+  type(kb_contour_gf)                 :: A(:)
+  type(kb_contour_gf)                 :: C
+  type(kb_contour_gf)                 :: Knew,Kold
+  type(kb_contour_params)             :: params
+  real(8),optional                    :: dcoeff
+  complex(8),optional                 :: ccoeff
+  integer                             :: N,L
+  integer                             :: i,j,k,itau,jtau,Na
+  logical                             :: checkA,checkC
+  !
+  Na = size(A)
+  !
+  if(  (.not.C%status))stop "contour_gf/convolute_kb_contour_gf: C not allocated"
+  do i=1,Na
+     if(  (.not.A(i)%status))stop "contour_gf/convolute_kb_contour_gf: A(i) not allocated"
+  enddo
+  !
+  call allocate_kb_contour_gf(Knew,params)
+  call allocate_kb_contour_gf(Kold,params)
+  !
+  N   = params%Nt      !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  !
+  if(N==1) stop "convolute_kb_contour_gf_gf_recursive error: called with N=1"
+  checkC=check_dimension_kb_contour(C,params%Ntime,L)
+  do i=1,Na
+     checkA=check_dimension_kb_contour(A(i),params%Ntime,L) 
+  enddo
+  !
+  !Perform the recursive convolution:
+  Kold = A(1)
+  do i=2,Na-1
+     call convolute_kb_contour_gf(Kold,A(i),Knew,params)
+     Kold=Knew
+  enddo
+  call convolute_kb_contour_gf(Knew,A(Na),C,params)
+  !
+  if(present(dcoeff))then
+     C%lmix(N,0:L) = dcoeff*C%lmix(N,0:L)
+     C%less(N,1:N-1)=dcoeff*C%less(N,1:N-1)
+     C%less(1:N,N)=dcoeff*C%less(1:N,N)
+     C%ret(N,1:N)=dcoeff*C%ret(N,1:N)
+  endif
+  if(present(ccoeff))then
+     C%lmix(N,0:L) = ccoeff*C%lmix(N,0:L)
+     C%less(N,1:N-1)=ccoeff*C%less(N,1:N-1)
+     C%less(1:N,N)=ccoeff*C%less(1:N,N)
+     C%ret(N,1:N)=ccoeff*C%ret(N,1:N)
+  endif
+  call deallocate_kb_contour_gf(Knew)
+  call deallocate_kb_contour_gf(Kold)
+  !    
+end subroutine convolute_kb_contour_gf_gf_recursive
+
+
+!C(t,t') = (a_1*a_2*...*a_n)(t,t')with t=t_max && t'=0,t_max; t_max_index==N
+! a_i = contour_gf    for i=j_1,...,j_ng
+! a_i = contour_sigma for i=k_1,...,k_ns
+subroutine convolute_kb_contour_gf_sigma_recursive(G,S,mask,P,params,dcoeff,ccoeff)
+  type(kb_contour_gf),dimension(:)    :: G     !array of contour_GF
+  type(kb_contour_sigma),dimension(:) :: S     !array of contour_Sigma
+  integer,dimension(:)                :: mask  !mask array to select contour_GF (0) over contour_Sigma (1)
+  type(kb_contour_gf)                 :: P     !result
+  type(kb_contour_params)             :: params
+  real(8),optional                    :: dcoeff
+  complex(8),optional                 :: ccoeff
+  integer                             :: Ng,Ns,Ntot
+  type(kb_contour_gf)                 :: Knew,Kold
+  integer                             :: N,L
+  integer                             :: i,j,k,ig,is
+  logical                             :: checkG,checkP,checkS
+  !
+  Ng   = size(G)
+  Ns   = size(S)
+  Ntot = size(Mask)
+  !
+  N   = params%Nt      !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  !
+  if(Ntot/=Ng+Ns)stop "convolute_kb_contour_gf_sigma_recursive error: Ntot != Ns + Ng"
+  if(N==1)stop "convolute_kb_contour_gf_sigma_recursive error: call with N=1"
+  do i=1,Ng
+     if(  (.not.G(i)%status) )stop "convolute_kb_contour_gf_sigma_recursive error: G(i) not allocated"
+  enddo
+  do i=1,Ns
+     if(  (.not.S(i)%status) )stop "convolute_kb_contour_gf_sigma_recursive error: S(i) not allocated"
+  enddo
+  if(  (.not.P%status) )stop "convolute_kb_contour_gf_sigma_recursive error: P not allocated"
+  do i=1,Ng
+     checkG=check_dimension_kb_contour(G(i),params) 
+  enddo
+  do i=1,Ns
+     checkS=check_dimension_kb_contour(S(i),params) 
+  enddo
+  checkP=check_dimension_kb_contour(P,params)
+  !
+  call allocate_kb_contour_gf(Knew,params)
+  call allocate_kb_contour_gf(Kold,params)
+  !
+  !check that mask does not contain 2 consecutive ones:
+  j=mask(1)
+  do i=2,Ntot
+     if(j*mask(i)/=0)then
+        print*,"convolute_kb_contour_gf_sigma_recursive error: mask has 2 consecutives ones at",i
+        stop
+     endif
+     j=mask(i)
+  enddo
+  !
+  !Perform the recursive convolution:
+  !get the first product P1 = g1/s1 * g2/s2 (can not be s1*s2 though)
+  !this step features 3 cases: i) g1*g2, ii) g1*s2, iii) s1*g2
+  is=1
+  ig=1
+  if(mask(1)==0.AND.mask(2)==0)then
+     ig=ig+1
+     call convolute_kb_contour_gf(G(1),G(ig),Kold,params)
+  elseif(mask(1)==1.AND.mask(2)==0)then
+     ig=ig+1
+     call convolute_kb_contour_gf(S(1),G(ig),Kold,params)
+  elseif(mask(1)==0.AND.mask(2)==1)then
+     is=is+1
+     call convolute_kb_contour_gf(G(1),S(is),Kold,params)
+  else
+     print*,"convolute_kb_contour_gf_sigma_recursive error: mask(1)==mask(2)==1"
+     stop
+  endif
+  !
+  do i=2,Ntot-1
+     if(mask(i)==0)then
+        ig=ig+1
+        call convolute_kb_contour_gf(Kold,G(ig),Knew,params)
+     elseif(mask(i)==1)then
+        is=is+1
+        call convolute_kb_contour_gf(Kold,S(is),Knew,params)
+     else
+        print*,"convolute_kb_contour_gf_sigma_recursive error: mask(i)!=1.OR.0"
+        stop
+     endif
+     Kold = Knew
+  enddo
+  if(mask(Ntot)==0)then
+     ig=ig+1
+     call convolute_kb_contour_gf(Kold,G(ig),P,params)
+  elseif(mask(Ntot)==1)then
+     is=is+1
+     call convolute_kb_contour_gf(Kold,S(is),P,params)
+  else
+     print*,"convolute_kb_contour_gf_sigma_recursive error: mask(Ntot)!=1.OR.0"
+     stop
+  endif
+  !
+  if(ig/=Ng.OR.is/=Ns)stop "convolute_kb_contour_gf_sigma_recursive error: ig!=Ng OR is!=Ns"
+  !
+  if(present(dcoeff))then
+     P%lmix(N,0:L) = dcoeff*P%lmix(N,0:L)
+     P%less(N,1:N-1)=dcoeff*P%less(N,1:N-1)
+     P%less(1:N,N)=dcoeff*P%less(1:N,N)
+     P%ret(N,1:N)=dcoeff*P%ret(N,1:N)
+  endif
+  if(present(ccoeff))then
+     P%lmix(N,0:L) = ccoeff*P%lmix(N,0:L)
+     P%less(N,1:N-1)=ccoeff*P%less(N,1:N-1)
+     P%less(1:N,N)=ccoeff*P%less(1:N,N)
+     P%ret(N,1:N)=ccoeff*P%ret(N,1:N)
+  endif
+  call deallocate_kb_contour_gf(Knew)
+  call deallocate_kb_contour_gf(Kold)
+  !    
+end subroutine convolute_kb_contour_gf_sigma_recursive
+
+
+
+!C(t,t')=(A*B)(t,t'), with t=t_max && t'=0,t_max; t_max_index==N
+! The case A(t,t')=A(t)delta(t,t')
+subroutine convolute_kb_contour_gf_delta_left(A,B,C,params)
+  type(kb_contour_gf)                 :: B,C
+  complex(8),dimension(:)             :: A
+  type(kb_contour_params)             :: params
+  integer                             :: N,L
+  integer                             :: i,j,k,itau,jtau
+  logical                             :: checkB,checkC
+  if(  (.not.B%status).OR.&
+       (.not.C%status))stop "convolute_kb_contour_gf_delta_left error: B,C not allocated"
+  N   = params%Nt      !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  !
+  if(size(A)<N)stop "convolute_kb_contour_gf_delta_left error: size(A) < N"
+  checkB=check_dimension_kb_contour(B,params%Ntime,L) 
+  checkC=check_dimension_kb_contour(C,params%Ntime,L)
+  !
+  ! Matsubara
+  if (N==1)C%mats = A(1)*B%mats
+  !Ret. component
+  do j=1,N
+     C%ret(n,j) = A(n)*B%ret(n,j)
+  enddo
+  !Less. component
+  do j=1,N
+     C%less(n,j) = A(n)*B%less(n,j)
+  enddo
+  !Lmix. component
+  do jtau=0,L
+     C%lmix(n,jtau) = A(n)*B%lmix(n,jtau)
+  enddo
+end subroutine convolute_kb_contour_gf_delta_left
+
+
+!C(t,t')=(A*B)(t,t'), with t=t_max && t'=0,t_max; t_max_index==N
+! The case B(t,t')=B(t)delta(t,t')
+subroutine convolute_kb_contour_gf_delta_right(A,B,C,params)
+  type(kb_contour_gf)                 :: A,C
+  complex(8),dimension(:)             :: B
+  type(kb_contour_params)             :: params
+  integer                             :: N,L
+  integer                             :: i,j,k,itau,jtau
+  logical                             :: checkA,checkC
+  if(  (.not.A%status).OR.&
+       (.not.C%status))stop "convolute_kb_contour_gf_delta_right error: A,C not allocated"
+  N   = params%Nt      !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  !
+  checkA=check_dimension_kb_contour(A,params%Ntime,L)
+  if(size(B)<N)stop "convolute_kb_contour_gf_delta_right error: size(B) < N"
+  checkC=check_dimension_kb_contour(C,params%Ntime,L)
+  !
+  ! Matsubara
+  if (N==1)C%mats(0:) = A%mats(0:)*B(1)
+  !Ret. component
+  do j=1,N
+     C%ret(n,j) = A%ret(n,j)*B(j)
+  enddo
+  !Less. component
+  do j=1,N
+     C%less(n,j) = A%less(n,j)*B(j)
+  enddo
+  !Lmix. component
+  do jtau=0,L
+     C%lmix(N,jtau) = A%lmix(N,jtau)*B(1)
+  enddo
+end subroutine convolute_kb_contour_gf_delta_right

--- a/neq_contour_gf_misc.f90
+++ b/neq_contour_gf_misc.f90
@@ -1,0 +1,350 @@
+! CHECK DIMENSION
+function check_dimension_kb_contour_gf(G,params) result(bool)
+  type(kb_contour_gf)     :: G
+  type(kb_contour_params) :: params
+  logical                 :: bool
+  integer                 :: N,L
+  bool=.false.
+  N=params%Ntime              !<== check size at maximum time
+  L=params%Ntau
+  if( (size(G%less)/=N**2) .OR. (size(G%ret)/=N**2) )&
+       stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions less/ret"
+  if( size(G%lmix)/=N*(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions lmix"
+  if( size(G%mats)/=(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions mats"
+  bool=.true.
+end function check_dimension_kb_contour_gf
+!
+function check_dimension_kb_contour_sigma(S,params) result(bool)
+  type(kb_contour_sigma)  :: S
+  type(kb_contour_params) :: params
+  logical                 :: bool
+  integer                 :: N,L
+  bool=.false.
+  N=params%Ntime              !<== check size at maximum time
+  L=params%Ntau
+  if( (size(S%reg%less)/=N**2) .OR. (size(S%reg%ret)/=N**2) )&
+       stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions less/ret"
+  if( size(S%reg%lmix)/=N*(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions lmix"
+  if( size(S%reg%mats)/=(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions mats"
+  if( size(S%hf)/=N )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions HF"
+  bool=.true.
+end function check_dimension_kb_contour_sigma
+!
+function check_dimension_kb_contour_gf_(G,N,L) result(bool)
+  type(kb_contour_gf)     :: G
+  logical                 :: bool
+  integer                 :: N,L
+  bool=.false.
+  if( (size(G%less)/=N**2) .OR. (size(G%ret)/=N**2) )&
+       stop "ERROR contour_gf/check_dimension_kb_contour_gf: wrong dimensions less/ret"
+  if( size(G%lmix)/=N*(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions lmix"
+  if( size(G%mats)/=(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions mats"
+  bool=.true.
+end function check_dimension_kb_contour_gf_
+!
+function check_dimension_kb_contour_sigma_(S,N,L) result(bool)
+  type(kb_contour_sigma)  :: S
+  logical                 :: bool
+  integer                 :: N,L
+  bool=.false.
+  if( (size(S%reg%less)/=N**2) .OR. (size(S%reg%ret)/=N**2) )&
+       stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions less/ret"
+  if( size(S%reg%lmix)/=N*(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions lmix"
+  if( size(S%reg%mats)/=(L+1) )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions mats"
+  if( size(S%hf)/=N )stop "contour_gf/check_dimension_kb_contour_gf: wrong dimensions HF"
+  bool=.true.
+end function check_dimension_kb_contour_sigma_
+!
+function check_dimension_kb_contour_dgf(dG,params) result(bool)
+  type(kb_contour_dgf)    :: dG
+  type(kb_contour_params) :: params
+  logical                 :: bool
+  integer                 :: N,L
+  bool=.false.
+  N=params%Ntime              !<== check size at maximum time
+  L=params%Ntau
+  if( (size(dG%less)/=N) .OR. (size(dG%ret)/=N) )&
+       stop "ERROR contour_gf/check_dimension_kb_contour_dgf: wrong dimensions less/ret"
+  if( size(dG%lmix)/=(L+1) )&
+       stop "ERROR contour_gf/check_dimension_kb_contour_dgf: wrong dimensions lmix"
+  bool=.true.
+end function check_dimension_kb_contour_dgf
+!
+function check_dimension_kb_contour_dgf_(dG,N,L) result(bool)
+  type(kb_contour_dgf)    :: dG
+  logical                 :: bool
+  integer                 :: N,L
+  bool=.false.
+  if( (size(dG%less)/=N) .OR. (size(dG%ret)/=N) )&
+       stop "ERROR contour_gf/check_dimension_kb_contour_dgf: wrong dimensions less/ret"
+  if( size(dG%lmix)/=(L+1) )&
+       stop "ERROR contour_gf/check_dimension_kb_contour_dgf: wrong dimensions lmix"
+  bool=.true.
+end function check_dimension_kb_contour_dgf_
+
+
+
+! SAVE
+subroutine save_kb_contour_gf(G,file)
+  type(kb_contour_gf) :: G
+  character(len=*)    :: file
+  integer             :: unit,N,L,Lf
+  if(.not.G%status)stop "contour_gf/save_kb_contour_gf: G not allocated"
+  unit = free_unit()
+  open(unit,file=reg(file)//"_dimension.data.neqipt")
+  N=size(G%less,1)
+  L=size(G%lmix,2)-1
+  Lf=size(G%iw)
+  write(unit,"(A1,3A4,3X)")"#","N","L","Lf"
+  write(unit,"(1X,3I4,3X)")N,L,Lf
+  close(unit)
+  call store_data(reg(file)//"_less.data.neqipt",G%less(:,:))
+  call store_data(reg(file)//"_ret.data.neqipt", G%ret(:,:))
+  call store_data(reg(file)//"_lmix.data.neqipt",G%lmix(:,0:))
+  call store_data(reg(file)//"_mats.data.neqipt",G%mats(0:))
+  call store_data(reg(file)//"_iw.data.neqipt",G%iw(:))
+end subroutine save_kb_contour_gf
+!
+subroutine save_kb_contour_sigma(S,file)
+  type(kb_contour_sigma) :: S
+  character(len=*)       :: file
+  integer                :: unit,i
+  if(.not.S%status)stop "contour_gf/save_kb_contour_gf: S not allocated"
+  unit = free_unit()
+  open(unit,file=reg(file)//"_hfb.data.neqipt")
+  do i=1,size(S%hf(:))
+     write(unit,*)S%hf(i)
+  enddo
+  close(unit)
+  call save_kb_contour_gf(S%reg,file)
+end subroutine save_kb_contour_sigma
+!
+subroutine save_kb_contour_dgf(dG,file)
+  type(kb_contour_dgf) :: dG
+  character(len=*)     :: file
+  integer              :: unit,N,L
+  if(.not.dG%status)stop "contour_gf/save_kb_contour_dgf: dG not allocated"
+  unit = free_unit()
+  N=size(dG%less)
+  L=size(dG%lmix)-1
+  open(unit,file=reg(file)//"_dimension.data.neqipt")
+  write(unit,"(A1,2A4,2X)")"#","N","L"
+  write(unit,"(1X,2I4,2X)")N,L
+  close(unit)
+  call store_data(reg(file)//"_less.data.neqipt",dG%less(:))
+  call store_data(reg(file)//"_ret.data.neqipt", dG%ret(:))
+  call store_data(reg(file)//"_lmix.data.neqipt",dG%lmix(0:))
+end subroutine save_kb_contour_dgf
+
+
+
+
+
+! READ
+subroutine read_kb_contour_gf(G,file)
+  type(kb_contour_gf)  :: G
+  character(len=*)     :: file
+  logical              :: check
+  check = inquire_kb_contour_gf(file)
+  if(.not.G%status.OR..not.check)stop "contour_gf/read_kb_contour_gf: G not allocated"
+  call read_data(trim(file)//"_less.data.neqipt",G%less(:,:))
+  call read_data(trim(file)//"_ret.data.neqipt",G%ret(:,:))
+  call read_data(trim(file)//"_lmix.data.neqipt",G%lmix(:,0:))
+  call read_data(trim(file)//"_mats.data.neqipt",G%mats(0:))
+  call read_data(trim(file)//"_iw.data.neqipt",G%iw(:))
+end subroutine read_kb_contour_gf
+!
+subroutine read_kb_contour_sigma(S,file)
+  type(kb_contour_sigma) :: S
+  character(len=*)       :: file
+  logical                :: check
+  integer                :: unit,i,Len
+  check = inquire_kb_contour_sigma(file)
+  if(.not.S%status.OR..not.check)stop "contour_gf/read_kb_contour_sigma: S not allocated"
+  Len  = file_length(reg(file)//"_hfb.data.neqipt")
+  if( Len > size(S%hf) ) stop"contour_gf/read_kb_contour_sigma: length(file) > size(S%hf)"
+  unit = free_unit()
+  open(unit,file=reg(file)//"_hfb.data.neqipt")
+  do i=1,Len
+     read(unit,*)S%hf(i)
+  enddo
+  close(unit)
+  call read_kb_contour_gf(S%reg,file)
+end subroutine read_kb_contour_sigma
+!
+subroutine read_kb_contour_dgf(dG,file)
+  type(kb_contour_dgf) :: dG
+  character(len=*)     :: file
+  logical              :: check
+  check = inquire_kb_contour_dgf(file)
+  if(.not.dG%status.OR..not.check)stop "contour_gf/read_kb_contour_dgf: dG not allocated"
+  call read_data(trim(file)//"_less.data.neqipt",dG%less(:))
+  call read_data(trim(file)//"_ret.data.neqipt",dG%ret(:))
+  call read_data(trim(file)//"_lmix.data.neqipt",dG%lmix(0:))
+end subroutine read_kb_contour_dgf
+!
+!
+!aux: inquire:
+function inquire_kb_contour_gf(file) result(check)
+  integer          :: i
+  logical          :: check,bool(5)
+  character(len=*) :: file
+  character(len=16),dimension(5)  :: ctype=([ character(len=5) :: 'less','ret','lmix','mats','iw'])
+  check=.true.
+  do i=1,5
+     inquire(file=reg(file)//"_"//reg(ctype(i))//".data.neqipt",exist=bool(i))
+     if(.not.bool(i))inquire(file=reg(file)//"_"//reg(ctype(i))//".data.neqipt.gz",exist=bool(i))
+     check=check.AND.bool(i)
+  enddo
+end function inquire_kb_contour_gf
+!
+function inquire_kb_contour_sigma(file) result(check)
+  integer          :: i
+  logical          :: check,bool(6)
+  character(len=*) :: file
+  character(len=16),dimension(5)  :: ctype=([ character(len=5) :: 'less','ret','lmix','mats','iw'])
+  check=.true.
+  do i=1,5
+     inquire(file=reg(file)//"_"//reg(ctype(i))//".data.neqipt",exist=bool(i))
+     if(.not.bool(i))inquire(file=reg(file)//"_"//reg(ctype(i))//".data.neqipt.gz",exist=bool(i))
+     check=check.AND.bool(i)
+  enddo
+  inquire(file=reg(file)//"_hfb.data.neqipt",exist=bool(6))
+  check=check.AND.bool(6)
+end function inquire_kb_contour_sigma
+!
+function inquire_kb_contour_dgf(file) result(check)
+  integer          :: i
+  logical          :: check,bool(3)
+  character(len=*) :: file
+  character(len=16),dimension(3)  :: ctype=([character(len=5) :: 'less','ret','lmix'])
+  check=.true.
+  do i=1,3
+     inquire(file=reg(file)//"_"//reg(ctype(i))//".data.neqipt",exist=bool(i))
+     if(.not.bool(i))inquire(file=reg(file)//"_"//reg(ctype(i))//".data.neqipt.gz",exist=bool(i))
+     check=check.AND.bool(i)
+  enddo
+end function inquire_kb_contour_dgf
+
+
+
+
+! PLOT
+subroutine plot_kb_contour_gf(file,G,params)
+  character(len=*)        :: file
+  type(kb_contour_gf)     :: G
+  type(kb_contour_params) :: params
+  integer                 :: Nt,i
+  if(.not.G%status)stop "contour_gf/plot_kb_contour_gf: G is not allocated" 
+  Nt=params%Ntime
+  call splot3d(reg(file)//"_less_t_t.data.neqipt",params%t(:Nt),params%t(:Nt),G%less(:Nt,:Nt))
+  call splot3d(reg(file)//"_ret_t_t.data.neqipt",params%t(:Nt),params%t(:Nt),G%ret(:Nt,:Nt))
+  call splot3d(reg(file)//"_lmix_t_tau.data.neqipt",params%t(:Nt),params%tau(0:),G%lmix(:Nt,0:))
+  call splot(reg(file)//"_mats_tau.data.neqipt",params%tau(0:),G%mats(0:))
+  call splot(reg(file)//"_mats_iw.data.neqipt",params%wm(:),G%iw(:))
+end subroutine plot_kb_contour_gf
+!
+subroutine plot_kb_contour_sigma(file,S,params)
+  character(len=*)        :: file
+  type(kb_contour_sigma)  :: S
+  type(kb_contour_params) :: params
+  integer                 :: Nt,i
+  if(.not.S%status)stop "contour_gf/plot_kb_contour_sigma: S is not allocated" 
+  Nt=params%Ntime
+  call splot3d(reg(file)//"_less_t_t.data.neqipt",params%t(:Nt),params%t(:Nt),S%reg%less(:Nt,:Nt))
+  call splot3d(reg(file)//"_ret_t_t.data.neqipt",params%t(:Nt),params%t(:Nt),S%reg%ret(:Nt,:Nt))
+  call splot3d(reg(file)//"_lmix_t_tau.data.neqipt",params%t(:Nt),params%tau(0:),S%reg%lmix(:Nt,0:))
+  call splot(reg(file)//"_mats_tau.data.neqipt",params%tau(0:),S%reg%mats(0:))
+  call splot(reg(file)//"_mats_iw.data.neqipt",params%wm(:),S%reg%iw(:)+S%hf(1))
+  call splot(reg(file)//"_hfb_t.data.neqipt",params%t(:Nt),S%hf(:Nt))
+end subroutine plot_kb_contour_sigma
+!
+subroutine plot_kb_contour_dgf(file,dG,params)
+  character(len=*)        :: file
+  type(kb_contour_dgf)    :: dG
+  type(kb_contour_params) :: params
+  integer                 :: Nt
+  if(.not.dG%status)stop "contour_gf/plot_kb_contour_gf: G is not allocated" 
+  Nt=params%Ntime
+  call splot(reg(file)//"_less_t.data.neqipt",params%t(:Nt),dG%less(:Nt))
+  call splot(reg(file)//"_ret_t.data.neqipt",params%t(:Nt),dG%ret(:Nt))
+  call splot(reg(file)//"_lmix_tau.data.neqipt",params%tau(0:),dG%lmix(0:))
+end subroutine plot_kb_contour_dgf
+
+
+
+
+
+
+! EXTRAPOLATION
+!extrapolate a function from a given time to the next one:
+subroutine extrapolate_kb_contour_gf(g,params)
+  type(kb_contour_gf)     :: g
+  type(kb_contour_params) :: params
+  integer                 :: i,j,k,N,L
+  if(.not.g%status)     stop "extrapolate_kb_contour_gf: g is not allocated"
+  if(.not.params%status)stop "extrapolate_kb_contour_gf: params is not allocated"
+  N = params%Nt
+  L = params%Ntau
+  select case(N)
+  case(1)
+     return
+  case(2)
+     !GUESS G AT THE NEXT STEP, GIVEN THE INITIAL CONDITIONS
+     do j=1,N
+        g%ret(N,j) =g%ret(1,1)
+        g%less(N,j)=g%less(1,1)
+     end do
+     do i=1,N-1
+        g%less(i,N)=g%less(1,1)
+     end do
+     do j=0,L
+        g%lmix(N,j)=g%lmix(1,j)
+     end do
+  case default
+     !EXTEND G FROM THE [N-1,N-1] TO THE [N,N] SQUARE TO START DMFT
+     !USING QUADRATIC EXTRAPOLATION
+     do k=1,N-1
+        g%less(N,k)=2.d0*g%less(N-1,k)-g%less(N-2,k)
+        g%less(k,N)=2.d0*g%less(k,N-1)-g%less(k,N-2)
+     end do
+     g%less(N,N)=2.d0*g%less(N-1,N-1)-g%less(N-2,N-2)
+     !
+     do k=0,L
+        g%lmix(N,k)=2.d0*g%lmix(N-1,k)-g%lmix(N-2,k)
+     end do
+     !
+     g%ret(N,N)=-xi
+     do k=1,N-2
+        g%ret(N,k)=2.d0*g%ret(N-1,k)-g%ret(N-2,k)
+     end do
+     g%ret(N,N-1)=0.5d0*(g%ret(N,N)+g%ret(N,N-2))
+  end select
+end subroutine extrapolate_kb_contour_gf
+
+subroutine extrapolate_kb_contour_sigma(s,params)
+  type(kb_contour_sigma)  :: s
+  type(kb_contour_params) :: params
+  integer                 :: i,j,k,N,L
+  if(.not.s%status)     stop "extrapolate_kb_contour_gf: g is not allocated"
+  if(.not.params%status)stop "extrapolate_kb_contour_gf: params is not allocated"
+  N = params%Nt
+  select case(N)
+  case(1)
+     return
+  case(2)
+     !GUESS Shf AT THE NEXT STEP, GIVEN THE INITIAL CONDITIONS
+     s%hf(N)=s%hf(1)
+  case default
+     !EXTEND Shf FROM THE [N-1,N-1] TO THE [N,N] SQUARE TO START DMFT
+     !USING QUADRATIC EXTRAPOLATION
+     S%hf(N)=2.d0*S%hf(N-1)-S%hf(N-2)
+  end select
+  call extrapolate_kb_contour_gf(s%reg,params)
+end subroutine extrapolate_kb_contour_sigma
+
+
+
+
+
+

--- a/neq_contour_gf_operations.f90
+++ b/neq_contour_gf_operations.f90
@@ -1,0 +1,322 @@
+!+-----------------------------------------------------------------------------+!
+!PURPOSE: define some special operations on the GF:
+! + get_adv : obtain the Adv component from G
+! + get_rmix: obtain the RightMix component from G
+! + get_gtr : obtain the Gtr component from G
+! + get_bar : obtain the conjugate component in the Nambu space from G (dubbed bar)
+!+-----------------------------------------------------------------------------+!
+function get_adv(G,i,j) result (adv)
+  implicit none
+  type(kb_contour_gf),intent(in) :: G
+  integer :: i,j
+  complex(8) :: adv
+  ! if (.not.G%anomalous) then
+  adv=conjg(G%ret(j,i))
+  return
+  ! else
+  !    adv=G%ret(j,i)
+  !    return
+  ! endif
+end function get_adv
+
+
+function get_rmix(G,i,j,L) result (rmix)
+  implicit none
+  type(kb_contour_gf),intent(in) :: G
+  integer :: i,j,L
+  complex(8) :: rmix
+  ! if (.not.G%anomalous) then
+  rmix=conjg(G%lmix(j,L-i))     !ACTHUNG!!! shouldn't it be -G*(beta-tau)?
+  return
+  ! else
+  !   rmix=G%lmix(j,i)
+  !   return
+  ! endif
+end function get_rmix
+
+
+function get_gtr(G,i,j) result (gtr)
+  implicit none
+  type(kb_contour_gf),intent(in) :: G
+  integer :: i,j
+  complex(8) :: gtr
+  ! if (.not.G%anomalous) then
+  gtr=G%less(i,j)+G%ret(i,j)
+  if (i < j)gtr=G%less(i,j)-conjg(G%ret(j,i))
+  return
+  ! else
+  !   gtr=G%less(j,i)
+  !   return
+  ! endif
+end function get_gtr
+
+
+! subroutine get_bar_gf(A,B,params)
+!   type(kb_contour_gf)                 :: A,B
+!   type(kb_contour_params)             :: params
+!   integer                             :: N,L,Lf
+!   real(8)                             :: dt,dtau
+!   integer                             :: i,j,k,itau,jtau
+!   logical                             :: checkA,checkB,checkC
+!   if(  (.not.A%status).OR.&
+!        (.not.B%status))stop "contour_gf/get_bar_kb_contour_gf: A,B,C not allocated"
+!   N   = params%Nt      !<== work with the ACTUAL size of the contour
+!   L   = params%Ntau
+!   Lf  = params%Niw
+!   dt  = params%dt
+!   dtau= params%dtau
+!   checkA=check_dimension_kb_contour(A,params%Ntime,L) 
+!   checkB=check_dimension_kb_contour(B,params%Ntime,L)
+!   !
+!   if (.not.B%anomalous) then
+!      if(N==1)then
+!         ! Matsubara imaginary time component
+!         A%mats(0:L) = B%mats(L:0:-1)
+!         ! Matsubara frequencies component
+!         A%iw = -conjg(B%iw)
+!      endif
+!      !Ret. component
+!      do j=1,N
+!         A%ret(n,j) = -conjg(B%ret(n,j))
+!      enddo
+!      !Lmix. component
+!      do jtau=0,L
+!         A%lmix(N,jtau) = -conjg(B%lmix(N,L-jtau))
+!      enddo
+!      !Less component
+!      do j=1,N-1
+!         A%less(N,j)=-B%less(j,N)+conjg(B%ret(N,j))
+!      end do
+!      ! (t,t')=>(i,N) <==> Horizontal side, w/ tip (i=1,N)
+!      do j=1,N-1
+!         A%less(j,N)=-B%less(N,j)-B%ret(N,j)
+!      end do
+!      !
+!   else
+!      !
+!      if(N==1)then
+!         ! Matsubara imaginary time component
+!         A%mats(0:L) = B%mats(0:L)
+!         ! Matsubara frequencies component
+!         A%iw = B%iw
+!      endif
+!      !Ret. component
+!      do j=1,N
+!         A%ret(n,j) =  conjg(B%ret(n,j))
+!      enddo
+!      !Lmix. component
+!      do jtau=0,L
+!         A%lmix(N,jtau) =  B%lmix(N,L-jtau)
+!      enddo
+!      !Less component
+!      do j=1,N-1
+!         A%less(N,j)=-conjg(B%less(j,N))
+!      end do
+!      ! (t,t')=>(i,N) <==> Horizontal side, w/ tip (i=1,N)
+!      do j=1,N-1
+!         B%less(N,j)=-conjg(B%less(j,N))
+!      end do
+!      !
+!   endif
+! end subroutine get_bar_gf
+
+
+! subroutine get_bar_sigma(A,B,params)
+!   type(kb_contour_sigma)              :: A,B
+!   type(kb_contour_params)             :: params
+!   integer                             :: N,L,Lf
+!   real(8)                             :: dt,dtau
+!   integer                             :: i,j,k,itau,jtau
+!   logical                             :: checkA,checkB,checkC
+!   if(  (.not.A%status).OR.&
+!        (.not.B%status))stop "contour_gf/get_bar_kb_contour_gf: A,B not allocated"
+!   N   = params%Nt      !<== work with the ACTUAL size of the contour
+!   L   = params%Ntau
+!   Lf  = params%Niw
+!   dt  = params%dt
+!   dtau= params%dtau
+!   checkA=check_dimension_kb_contour(A,params%Ntime,L) 
+!   checkB=check_dimension_kb_contour(B,params%Ntime,L)
+!   if (.not.B%reg%anomalous) then
+!      if(N==1)then
+!         ! Matsubara imaginary time component
+!         A%reg%mats(0:L) = B%reg%mats(L:0:-1)
+!         ! Matsubara frequencies component
+!         A%reg%iw = -conjg(B%reg%iw)
+!      endif
+!      !Ret. component
+!      do j=1,N
+!         A%reg%ret(n,j) = -conjg(B%reg%ret(n,j))
+!      enddo
+!      !Lmix. component
+!      do jtau=0,L
+!         A%reg%lmix(N,jtau) = -conjg(B%reg%lmix(N,L-jtau))
+!      enddo
+!      !Less component
+!      do j=1,N-1
+!         A%reg%less(N,j)=-B%reg%less(j,N)+conjg(B%reg%ret(N,j))
+!      end do
+!      ! (t,t')=>(i,N) <==> Horizontal side, w/ tip (i=1,N)
+!      do j=1,N-1
+!         A%reg%less(j,N)=-B%reg%less(N,j)-B%reg%ret(N,j)
+!      end do
+!      !HF components:
+!      A%hf(:) = -conjg(B%hf(:))
+!      !
+!   else
+!      !
+!      if(N==1)then
+!         ! Matsubara imaginary time component
+!         A%reg%mats(0:L) = B%reg%mats(0:L)
+!         ! Matsubara frequencies component
+!         A%reg%iw = B%reg%iw
+!      endif
+!      !Ret. component
+!      do j=1,N
+!         A%reg%ret(n,j) =  conjg(B%reg%ret(n,j))
+!      enddo
+!      !Lmix. component
+!      do jtau=0,L
+!         A%reg%lmix(N,jtau) =  B%reg%lmix(N,L-jtau)
+!      enddo
+!      !Less component
+!      do j=1,N-1
+!         A%reg%less(N,j)=-conjg(B%reg%less(j,N))
+!      end do
+!      ! (t,t')=>(i,N) <==> Horizontal side, w/ tip (i=1,N)
+!      do j=1,N-1
+!         B%reg%less(N,j)=-conjg(B%reg%less(j,N))
+!      end do
+!      !HF components:
+!      A%hf(:) = B%hf(:)
+!      !	
+!   endif
+! end subroutine get_bar_sigma
+
+
+
+
+!+-----------------------------------------------------------------------------+!
+!PURPOSE: define some standard operations useful in the code such as
+! + equalities among contour GF.
+! + product of contour GF times a scalar.
+!+-----------------------------------------------------------------------------+!
+!
+!EQUALITIES:
+subroutine kb_contour_gf_equality_(G1,C)
+  type(kb_contour_gf),intent(inout) :: G1
+  complex(8),intent(in)             :: C
+  G1%less(:,:)  = C
+  G1%ret(:,:)   = C
+  G1%lmix(:,0:) = C
+  G1%mats(0:)   = C
+  G1%iw(:)      = C
+end subroutine kb_contour_gf_equality_
+!
+subroutine kb_contour_gf_equality__(G1,G2)
+  type(kb_contour_gf),intent(inout) :: G1
+  type(kb_contour_gf),intent(in)    :: G2
+  G1%less(:,:)  = G2%less(:,:)
+  G1%ret(:,:)   = G2%ret(:,:)
+  G1%lmix(:,0:) = G2%lmix(:,0:)
+  G1%mats(0:)   = G2%mats(0:)
+  G1%iw(:)      = G2%iw(:)
+end subroutine kb_contour_gf_equality__
+!
+subroutine kb_contour_dgf_equality_(dG1,C)
+  type(kb_contour_dgf),intent(inout) :: dG1
+  complex(8),intent(in)             :: C
+  dG1%less(:)  = C
+  dG1%ret(:)   = C
+  dG1%lmix(0:) = C
+end subroutine kb_contour_dgf_equality_
+!
+subroutine kb_contour_dgf_equality__(dG1,dG2)
+  type(kb_contour_dgf),intent(inout) :: dG1
+  type(kb_contour_dgf),intent(in)    :: dG2
+  dG1%less(:)  = dG2%less(:)
+  dG1%ret(:)   = dG2%ret(:)
+  dG1%lmix(0:) = dG2%lmix(0:)
+end subroutine kb_contour_dgf_equality__
+!
+!
+!PRODUCT times SCALAR:
+function kb_contour_gf_scalarL_d(C,G) result(F)
+  real(8),intent(in)             :: C
+  type(kb_contour_gf),intent(in) :: G
+  type(kb_contour_gf)            :: F
+  F%less(:,:) = C*G%less(:,:)
+  F%ret(:,:)  = C*G%ret(:,:)
+  F%lmix(:,0:)= C*G%lmix(:,0:)
+  F%mats(0:)  = C*G%mats(0:)
+  F%iw(:)     = C*G%iw(:)
+end function kb_contour_gf_scalarL_d
+!
+function kb_contour_dgf_scalarL_d(C,dG) result(dF)
+  real(8),intent(in)             :: C
+  type(kb_contour_dgf),intent(in) :: dG
+  type(kb_contour_dgf)            :: dF
+  dF%less(:) = C*dG%less(:)
+  dF%ret(:)  = C*dG%ret(:)
+  dF%lmix(0:)= C*dG%lmix(0:)
+end function kb_contour_dgf_scalarL_d
+!
+function kb_contour_gf_scalarL_c(C,G) result(F)
+  complex(8),intent(in)          :: C
+  type(kb_contour_gf),intent(in) :: G
+  type(kb_contour_gf)            :: F
+  F%less(:,:) = C*G%less(:,:)
+  F%ret(:,:)  = C*G%ret(:,:)
+  F%lmix(:,0:)= C*G%lmix(:,0:)
+  F%mats(0:)  = C*G%mats(0:)
+  F%iw(:)     = C*G%iw(:)
+end function kb_contour_gf_scalarL_c
+!
+function kb_contour_dgf_scalarL_c(C,dG) result(dF)
+  complex(8),intent(in)           :: C
+  type(kb_contour_dgf),intent(in) :: dG
+  type(kb_contour_dgf)            :: dF
+  dF%less(:) = C*dG%less(:)
+  dF%ret(:)  = C*dG%ret(:)
+  dF%lmix(0:)= C*dG%lmix(0:)
+end function kb_contour_dgf_scalarL_c
+!
+function kb_contour_gf_scalarR_d(G,C) result(F)
+  real(8),intent(in)             :: C
+  type(kb_contour_gf),intent(in) :: G
+  type(kb_contour_gf)            :: F
+  F%less(:,:) = G%less(:,:)*C
+  F%ret(:,:)  = G%ret(:,:)*C
+  F%lmix(:,0:)= G%lmix(:,0:)*C
+  F%mats(0:)  = G%mats(0:)*C
+  F%iw(:)     = G%iw(:)*C
+end function kb_contour_gf_scalarR_d
+!
+function kb_contour_dgf_scalarR_d(dG,C) result(dF)
+  real(8),intent(in)             :: C
+  type(kb_contour_dgf),intent(in) :: dG
+  type(kb_contour_dgf)            :: dF
+  dF%less(:) = dG%less(:)*C
+  dF%ret(:)  = dG%ret(:)*C
+  dF%lmix(0:)= dG%lmix(0:)*C
+end function kb_contour_dgf_scalarR_d
+!
+function kb_contour_gf_scalarR_c(G,C) result(F)
+  complex(8),intent(in)             :: C
+  type(kb_contour_gf),intent(in) :: G
+  type(kb_contour_gf)            :: F
+  F%less(:,:) = G%less(:,:)*C
+  F%ret(:,:)  = G%ret(:,:)*C
+  F%lmix(:,0:)= G%lmix(:,0:)*C
+  F%mats(0:)  = G%mats(0:)*C
+  F%iw(:)     = G%iw(:)*C
+end function kb_contour_gf_scalarR_c
+!
+function kb_contour_dgf_scalarR_c(dG,C) result(dF)
+  complex(8),intent(in)             :: C
+  type(kb_contour_dgf),intent(in) :: dG
+  type(kb_contour_dgf)            :: dF
+  dF%less(:) = dG%less(:)*C
+  dF%ret(:)  = dG%ret(:)*C
+  dF%lmix(0:)= dG%lmix(0:)*C
+end function kb_contour_dgf_scalarR_c

--- a/neq_contour_gf_sum.f90
+++ b/neq_contour_gf_sum.f90
@@ -1,0 +1,185 @@
+! performs the sum a*A + b*B and stores it in C along the perimeter
+! can be called multiple times to add up. 
+subroutine sum_kb_contour_gf_simple(A,ak,B,bk,C,params,iaddup)
+  type(kb_contour_gf)               :: A,B
+  type(kb_contour_gf),intent(inout) :: C
+  real(8)                           :: ak,bk
+  type(kb_contour_params)           :: params
+  integer                           :: N,L
+  logical,optional                  :: iaddup
+  logical                           :: iaddup_
+  iaddup_=.false.;if(present(iaddup))iaddup_=iaddup
+  !
+  N   = params%Nt   !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  !
+  if(  (.not.A%status).OR.&
+       (.not.B%status).OR.&
+       (.not.C%status))stop "contour_gf/addup_kb_contour_gf: G or Gk not allocated"
+  !
+  if(.not.iaddup_)call del_kb_contour_gf(C,params)
+  !
+  if(N==1)then
+     C%mats(0:) = ak*A%mats(0:) + bk*B%mats(0:)
+     C%iw(:)    = ak*A%iw(:)    + bk*B%iw(:)
+  endif
+  C%ret(N,1:N)   = ak*A%ret(N,1:N)   + bk*B%ret(N,1:N)
+  C%less(N,1:N)  = ak*A%less(N,1:N)  + bk*B%less(N,1:N)
+  C%lmix(N,0:)   = ak*A%lmix(N,0:)   + bk*B%lmix(N,0:)
+  !
+  !THIS SHOULD NOT BE INVOLVED IN THE CALCULATION:
+  ! if(.not.C%anomalous)then
+  C%less(1:N-1,N)= -conjg(C%less(N,1:N-1))
+  ! else
+  !    C%less(1:N-1,N)= C%less(N,1:N-1)+C%ret(N,1:N-1)
+  ! endif
+end subroutine sum_kb_contour_gf_simple
+
+subroutine sum_kb_contour_gf_recursive(A,ak,C,params,iaddup)
+  type(kb_contour_gf)               :: A(:)
+  real(8)                           :: ak(size(A))
+  type(kb_contour_gf),intent(inout) :: C
+  type(kb_contour_params)           :: params
+  integer                           :: N,L,Na,i
+  logical,optional                  :: iaddup
+  logical                           :: iaddup_
+  iaddup_=.false.;if(present(iaddup))iaddup_=iaddup
+  !
+  Na=size(A)
+  N   = params%Nt   !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  !
+  do i=1,Na
+     if((.not.A(i)%status) )stop "contour_gf/sum_kb_contour_gf: G or Gk not allocated"
+  enddo
+  if( (.not.C%status) )stop "contour_gf/addup_kb_contour_gf: G or Gk not allocated"
+  if(.not.iaddup_)call del_kb_contour_gf(C,params)
+  !
+  if(N==1)then
+     do i=1,Na
+        C%mats(0:) = C%mats(0:) + ak(i)*A(i)%mats(0:)
+        C%iw(:)    = C%iw(:)    + ak(i)*A(i)%iw(:)
+     enddo
+  endif
+  do i=1,Na
+     C%ret(N,1:N)   = C%ret(N,1:N)  + ak(i)*A(i)%ret(N,1:N)
+     C%less(N,1:N)  = C%less(N,1:N) + ak(i)*A(i)%less(N,1:N)
+     C%lmix(N,0:)   = C%lmix(N,0:)  + ak(i)*A(i)%lmix(N,0:)
+  enddo
+  !
+  ! if(.not.C%anomalous)then
+  C%less(1:N-1,N)= -conjg(C%less(N,1:N-1))
+  ! else
+  !    C%less(1:N-1,N)= C%less(N,1:N-1)+C%ret(N,1:N-1)
+  ! endif
+end subroutine sum_kb_contour_gf_recursive
+
+subroutine sum_kb_contour_gf_delta_d(A,ak,B,bk,C,params,iaddup)
+  type(kb_contour_gf)               :: A
+  real(8),dimension(:)              :: B
+  type(kb_contour_gf),intent(inout) :: C
+  real(8)                           :: ak,bk
+  type(kb_contour_params)           :: params
+  integer                           :: N,L
+  logical,optional                  :: iaddup
+  logical                           :: iaddup_
+  iaddup_=.false.;if(present(iaddup))iaddup_=iaddup
+  !
+  N   = params%Nt   !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  !
+  if(  (.not.A%status).OR.&
+       (.not.C%status))stop "contour_gf/addup_kb_contour_gf: G or Gk not allocated"
+  !
+  if(.not.iaddup_)call del_kb_contour_gf(C,params)
+  !
+  if(N==1)then 
+     C%mats(0)  = ak*A%mats(0)  + B(1)
+     C%mats(1:) = ak*A%mats(1:)
+  endif
+  C%ret(N,1:N)   = ak*A%ret(N,1:N)
+  C%less(N,1:N)  = ak*A%less(N,1:N)
+  C%lmix(N,0:)   = ak*A%lmix(N,0:)
+  !
+  ! if(.not.C%anomalous)then
+  C%less(1:N-1,N)= -conjg(C%less(N,1:N-1))
+  ! else
+  !    C%less(1:N-1,N)= C%less(N,1:N-1)+C%ret(N,1:N-1)
+  ! endif
+  C%ret(N,N) = C%ret(N,N) + B(N)
+end subroutine sum_kb_contour_gf_delta_d
+
+subroutine sum_kb_contour_gf_delta_c(A,ak,B,bk,C,params,iaddup)
+  type(kb_contour_gf)               :: A
+  complex(8),dimension(:)           :: B
+  type(kb_contour_gf),intent(inout) :: C
+  real(8)                           :: ak,bk
+  type(kb_contour_params)           :: params
+  integer                           :: N,L
+  logical,optional                  :: iaddup
+  logical                           :: iaddup_
+  iaddup_=.false.;if(present(iaddup))iaddup_=iaddup
+  !
+  N   = params%Nt   !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  !
+  if(  (.not.A%status).OR.&
+       (.not.C%status))stop "contour_gf/addup_kb_contour_gf: G or Gk not allocated"
+  !
+  if(.not.iaddup_)call del_kb_contour_gf(C,params)
+  !
+  if(N==1)then 
+     C%mats(0)  = ak*A%mats(0)  + B(1)
+     C%mats(1:) = ak*A%mats(1:)
+  endif
+  C%ret(N,1:N)   = ak*A%ret(N,1:N) 
+  C%less(N,1:N)  = ak*A%less(N,1:N)
+  C%lmix(N,0:)   = ak*A%lmix(N,0:)
+  !
+  ! if(.not.C%anomalous)then
+  C%less(1:N-1,N)= -conjg(C%less(N,1:N-1))
+  ! else
+  !    C%less(1:N-1,N)= C%less(N,1:N-1)+C%ret(N,1:N-1)
+  ! endif
+  C%ret(N,N) = C%ret(N,N) + B(N)
+end subroutine sum_kb_contour_gf_delta_c
+
+
+
+
+
+
+
+
+
+
+
+!======= DEL ======= 
+! reset the function along the actual perimeter to zero:
+subroutine del_kb_contour_gf(G,params)
+  type(kb_contour_gf)     :: G
+  type(kb_contour_params) :: params
+  integer                 :: N,L
+  if(  (.not.G%status)) stop "contour_gf/addup_kb_contour_gf: G or Gk not allocated"
+  N   = params%Nt   !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  if(N==1)then
+     G%iw = zero
+     G%mats = 0d0
+  endif
+  G%ret(N,1:N)   = zero
+  G%less(N,1:N)  = zero
+  G%lmix(N,0:)   = zero
+end subroutine del_kb_contour_gf
+
+subroutine del_kb_contour_dgf(dG,params)
+  type(kb_contour_dgf)    :: dG
+  type(kb_contour_params) :: params
+  integer                 :: N,L
+  if(  (.not.dG%status))stop "contour_gf/del_kb_contour_dgf: dG not allocated"
+  N   = params%Nt                 !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  dG%less(1:N) = zero
+  dG%ret(1:N)  = zero
+  dG%lmix(0:)  = zero
+end subroutine del_kb_contour_dgf

--- a/neq_contour_gf_vide.f90
+++ b/neq_contour_gf_vide.f90
@@ -1,0 +1,205 @@
+!----------------------------------------------------------------------------
+!  This subroutine solves a Volterra integro-differential equation of 
+!  the second kind,
+!              [i*d/dt-h(t)]G(t,t') = delta(t,t') + (K*G)(t,t'),
+!  for t=n*dt or t'=n*dt, using 2^nd implicit Runge-Kutta method.
+!----------------------------------------------------------------------------
+!K = contour_GF
+!H = H_0 + Sigma_HF
+subroutine vide_kb_contour_gf_K(H,K,G,dG,dG_new,params)
+  complex(8),dimension(:)             :: H
+  type(kb_contour_gf),intent(in)      :: K
+  type(kb_contour_gf),intent(inout)   :: G
+  type(kb_contour_dgf),intent(inout)  :: dG
+  type(kb_contour_dgf)                :: dG_new
+  type(kb_contour_params),intent(in)  :: params
+  integer                             :: N,L
+  real(8)                             :: dt,dtau
+  integer                             :: i,j,itau,jtau,s
+  complex(8),dimension(:),allocatable :: KxG
+  complex(8)                          :: dG_less
+  !
+  N   = params%Nt                 !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  dt  = params%dt
+  dtau= params%dtau
+  !
+  allocate(KxG(0:max(N,L)))
+  !
+  !TYPE: X=RET,LESS,LMIX (R,<,\LMIX)
+  !i d/dt G^x(t,:)  = h(t)G^x(t,:) + Q^x(t,:) + int_{0,t'}^{t}K^R(t,s)G^x(s,:)ds
+  !
+  !
+  !ret component
+  ! d/dt G^R(t,:) = -i*h(t)*G^R(t,:) -i*delta(t,:) - i\int_{:}^t K^R(t,s)*G^R(s,:)ds
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -   
+  G%ret(N,N)=-xi
+  dG_new%ret(N)=-xi*H(N)*G%ret(N,N)
+  do j=1,N-1
+     G%ret(N,j)=G%ret(N-1,j) + 0.5d0*dt*dG%ret(j)
+     !
+     KxG(0:)=zero
+     do s=j,N-1
+        KxG(s)=K%ret(N,s)*G%ret(s,j)
+     enddo
+     dG_new%ret(j)=-xi*dt*kb_half_trapz(KxG(0:),j,N-1)
+     !
+     G%ret(N,j)=G%ret(N,j) + 0.5d0*dt*dG_new%ret(j)
+     G%ret(N,j)=G%ret(N,j)/(1.d0 + 0.5d0*xi*dt*H(N) + 0.25d0*xi*dt**2*K%ret(N,N))
+     !
+     dG_new%ret(j)=dG_new%ret(j) - xi*H(N)*G%ret(N,j) - 0.5d0*xi*dt*K%ret(N,N)*G%ret(N,j)
+  enddo
+  !
+  !Lmix component
+  !d/dt G^\lmix(t,:) = -i*H(t)*G^\lmix(t,:) -i\int_0^\beta K^\lmix(t,s)*G^M(s,:)ds -i\int_0^t K^R(t,s)G^\lmix(s,:)ds
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -   
+  do jtau=0,L
+     G%lmix(N,jtau)=G%lmix(N-1,jtau)+0.5d0*dt*dG%lmix(jtau)
+     !
+     KxG(0:)=zero
+     do s=0,jtau
+        KxG(s)=K%lmix(N,s)*G%mats(s+L-jtau)
+     end do
+     dG_new%lmix(jtau)=xi*dtau*kb_trapz(KxG(0:),0,jtau)
+     KxG(0:)=zero
+     do s=jtau,L
+        KxG(s)=K%lmix(N,s)*G%mats(s-jtau)
+     end do
+     dG_new%lmix(jtau)=dG_new%lmix(jtau)-xi*dtau*kb_trapz(KxG(0:),jtau,L)!<= add -iQ(t)
+     !
+     KxG(0:)=zero
+     do s=1,N-1
+        KxG(s)=K%ret(N,s)*G%lmix(s,jtau)
+     end do
+     dG_new%lmix(jtau)=dG_new%lmix(jtau)-xi*dt*kb_half_trapz(KxG(0:),1,N-1)
+     !
+     G%lmix(N,jtau)=G%lmix(N,jtau) + 0.5d0*dt*dG_new%lmix(jtau)
+     G%lmix(N,jtau)=G%lmix(N,jtau)/(1.d0 + 0.5d0*xi*dt*H(N) + 0.25d0*xi*dt**2*K%ret(N,N))
+     !
+     dG_new%lmix(jtau)=dG_new%lmix(jtau)-xi*H(N)*G%lmix(N,jtau)-0.5d0*xi*dt*K%ret(N,N)*G%lmix(N,jtau)
+  end do
+  !
+  !Less component
+  !d/dt G^<(t,:) = -i*H(t)*G^<(t,:) -i*[ (-i)*\int_0^\beta K^\lmix(t,s)*G^\rmix(s,:)ds + \int_0^{:}K^<(t,s)*G^A(s,:)ds ]
+  !                                 -i*\int_0^t K^R(t,s)*G^<(s,:)ds
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -   
+  ! G^<(t_{N},t_{j}), d/dt G^<(t_{N},t_{j}) <== lower-right triangle
+  do j=1,N-1
+     G%less(N,j)=G%less(N-1,j) + 0.5d0*dt*dG%less(j)
+     !
+     KxG(0:)=zero
+     do s=0,L
+        KxG(s)=K%lmix(N,s)*get_rmix(G,s,j,L)
+     end do
+     dG_new%less(j)=-xi*(-xi)*dtau*kb_trapz(KxG(0:),0,L)
+     !
+     KxG(0:)=zero
+     do s=1,j
+        KxG(s)=K%less(N,s)*get_adv(G,s,j)
+     end do
+     dG_new%less(j)=dG_new%less(j)-xi*dt*kb_trapz(KxG(0:),1,j)!<= -iQ(t)
+     !
+     KxG(0:)=zero
+     do s=1,N-1
+        KxG(s)=K%ret(N,s)*G%less(s,j)
+     end do
+     dG_new%less(j)=dG_new%less(j)-xi*dt*kb_half_trapz(KxG(0:),1,N-1)
+     !
+     G%less(N,j)=G%less(N,j) + 0.5d0*dt*dG_new%less(j)
+     G%less(N,j)=G%less(N,j)/(1.d0 + 0.5d0*xi*dt*H(N) + 0.25d0*xi*dt**2*K%ret(N,N))
+     !
+     dG_new%less(j)=dG_new%less(j)-xi*H(N)*G%less(N,j)-0.5d0*xi*dt*K%ret(N,N)*G%less(N,j)
+  end do
+  !
+  ! G^<(t_{i},t_{N}), d/dt G^<(t_{i},t_{N}) <== upper left triangle
+  ! Hermitian conjugate G
+  ! if (.not.G%anomalous) then
+  do i=1,N-1
+     G%less(i,N)=-conjg(G%less(N,i))
+  end do
+  ! else
+  !    do i=1,N-1
+  !       G%less(i,N)=G%less(N,i)+G%ret(N,i)
+  !    end do
+  ! endif
+  !
+  ! d/dt G^<(t_{N-1},t_{N})
+  dG_less=-xi*H(N-1)*G%less(N-1,N)
+  !
+  KxG(0:)=zero
+  do s=0,L
+     KxG(s)=K%lmix(N-1,s)*get_rmix(G,s,N,L)
+  end do
+  dG_less=dG_less-xi*(-xi)*dtau*kb_trapz(KxG(0:),0,L)
+  !
+  KxG(0:)=zero
+  do s=1,N
+     KxG(s)=K%less(N-1,s)*get_adv(G,s,N)
+  end do
+  dG_less=dG_less-xi*dt*kb_trapz(KxG(0:),1,N)
+  !
+  KxG(0:)=zero
+  do s=1,N-1
+     KxG(s)=K%ret(N-1,s)*G%less(s,N)
+  end do
+  dG_less=dG_less-xi*dt*kb_trapz(KxG(0:),1,N-1)
+  !
+  !G^<(N,N), d/dt G^<(N,N)
+  G%less(N,N)=G%less(N-1,N)+0.5d0*dt*dG_less
+  !
+  KxG(0:)=zero
+  do s=0,L
+     KxG(s)=K%lmix(N,s)*get_rmix(G,s,N,L)
+  end do
+  dG_new%less(N)=-xi*(-xi)*dtau*kb_trapz(KxG(0:),0,L)
+  !
+  KxG(0:)=zero
+  do s=1,N
+     KxG(s)=K%less(N,s)*get_adv(G,s,N)
+  end do
+  dG_new%less(N)=dG_new%less(N)-xi*dt*kb_trapz(KxG(0:),1,N)
+  !
+  KxG(0:)=zero
+  do s=1,N-1
+     KxG(s)=K%ret(N,s)*G%less(s,N)
+  end do
+  dG_new%less(N)=dG_new%less(N)-xi*dt*kb_half_trapz(KxG(0:),1,N-1)
+  !
+  G%less(N,N)=G%less(N,N)+0.5d0*dt*dG_new%less(N)
+  G%less(N,N)=G%less(N,N)/(1.d0+0.5d0*xi*dt*H(N)+0.25d0*xi*dt**2*K%ret(N,N))
+  !
+  dG_new%less(N)=dG_new%less(N)-xi*H(N)*G%less(N,N)-0.5d0*xi*dt*K%ret(N,N)*G%less(N,N)
+  !
+  deallocate(KxG)
+end subroutine vide_kb_contour_gf_K
+
+!K = contour_Sigma
+!H = H_0
+subroutine vide_kb_contour_gf_Sigma(H0,Sigma,G,dG,dG_new,params)
+  complex(8),dimension(:)             :: H0
+  type(kb_contour_sigma),intent(in)   :: Sigma
+  type(kb_contour_gf),intent(inout)   :: G
+  type(kb_contour_dgf),intent(inout)  :: dG
+  type(kb_contour_dgf)                :: dG_new
+  type(kb_contour_params),intent(in)  :: params
+  complex(8),dimension(size(H0))      :: H
+  type(kb_contour_gf)                 :: K
+  integer                             :: N,L
+  real(8)                             :: dt,dtau
+  integer                             :: i,j,itau,jtau,s
+  complex(8),dimension(:),allocatable :: KxG
+  complex(8)                          :: dG_less
+  !
+  N   = params%Nt                 !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  dt  = params%dt
+  dtau= params%dtau
+  !
+  call allocate_kb_contour_gf(K,params)
+  K = Sigma%reg
+  H = H0 - Sigma%hf(:)
+  !
+  call vide_kb_contour_gf_K(H,K,G,dG,dG_new,params)
+  !
+  call deallocate_kb_contour_gf(K)
+end subroutine vide_kb_contour_gf_Sigma

--- a/neq_contour_gf_vie.f90
+++ b/neq_contour_gf_vie.f90
@@ -1,0 +1,401 @@
+!----------------------------------------------------------------------------
+!  This subroutine solves a Volterra integral equation of the second kind,
+!              G(t,t') = Q(t,t') + (K*G)(t,t')
+!  for t=n*dt or t'=n*dt, using 2^nd *implicit* Runge-Kutta method.
+!----------------------------------------------------------------------------
+!Q = Q(t,t'); K = contour_gf
+subroutine vie_kb_contour_gf_q(Q,K,G,params)
+  type(kb_contour_gf),intent(in)      :: Q
+  type(kb_contour_gf),intent(in)      :: K
+  type(kb_contour_gf),intent(inout)   :: G
+  type(kb_contour_params),intent(in)  :: params
+  integer                             :: N,L
+  real(8)                             :: dt,dtau
+  integer                             :: i,j,s,itau,jtau
+  complex(8),dimension(:),allocatable :: KxG
+  !
+  N   = params%Nt                 !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  dt  = params%dt
+  dtau= params%dtau
+  !
+  allocate(KxG(0:max(N,L)))
+  !
+  ! Ret component
+  ! G^R(t,t') - \int_{t'}^t K^R(t,s)*G^R(s,t')ds = Q^R(t,t')
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  G%ret(N,N)=Q%ret(N,N)
+  do j=1,N-1
+     G%ret(N,j)=Q%ret(N,j)
+     KxG(0:)=zero
+     do s=j,N-1
+        KxG(s)=K%ret(N,s)*G%ret(s,j)
+     eNd do
+     G%ret(N,j)=G%ret(N,j) + dt*kb_half_trapz(KxG(0:),j,N-1)
+     G%ret(N,j)=G%ret(N,j)/(1.d0-0.5d0*dt*K%ret(N,N))
+  end do
+  !
+  ! Lmix component
+  ! G^\lmix(t,tau') - \int_0^t K^R(t,s)*G^\lmix(s,tau')ds
+  !    = Q^\lmix(t,tau') + \int_0^\beta K^\lmix(t,s)*G^M(s,tau')ds
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  do jtau=0,L
+     G%lmix(N,jtau)=Q%lmix(N,jtau)
+     !
+     KxG(0:)=zero
+     do s=0,jtau
+        KxG(s)=K%lmix(N,s)*G%mats(s+L-jtau)
+     end do
+     G%lmix(N,jtau)=G%lmix(N,jtau)-dtau*kb_trapz(KxG(0:),0,jtau)
+     KxG(0:)=zero
+     do s=jtau,L
+        KxG(s)=K%lmix(N,s)*G%mats(s-jtau)
+     end do
+     G%lmix(N,jtau)=G%lmix(N,jtau)+dtau*kb_trapz(KxG(0:),jtau,L)
+     !
+     KxG(0:)=zero
+     do s=1,N-1
+        KxG(s)=K%ret(N,s)*G%lmix(s,jtau)
+     end do
+     G%lmix(N,jtau)=G%lmix(N,jtau) + dt*kb_half_trapz(KxG(0:),1,N-1)
+     !
+     G%lmix(N,jtau)=G%lmix(N,jtau)/(1.d0-0.5d0*dt*K%ret(N,N))
+  end do
+  !
+  ! Less component
+  ! G^<(t,t') - \int_0^t K^{R}(t,s)*G^{<}(s,t')ds
+  !    = Q^<(t,t') - i\int_0^\beta K^\lmix(t,s)*G^\rmix(s,t')ds
+  !      + \int_0^{t'} K^<(t,s)*G^A(s,t')ds
+  ! G^<(t_{N},t_{j})
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  do j=1, N-1
+     G%less(N,j)=Q%less(N,j)
+     !
+     KxG(0:)=zero
+     do s=0,L
+        KxG(s)=K%lmix(N,s)*get_rmix(G,s,j,L)
+     enddo
+     G%less(N,j)=G%less(N,j)-xi*dtau*kb_trapz(KxG(0:),0,L)
+     !
+     KxG(0:)=zero
+     do s=1,j
+        KxG(s)=K%less(N,s)*get_adv(G,s,j)
+     enddo
+     G%less(N,j)=G%less(N,j)+dt*kb_trapz(KxG(0:),1,j)
+     !
+     KxG(0:)=zero
+     do s=1,N-1
+        KxG(s)=K%ret(N,s)*G%less(s,j)
+     enddo
+     G%less(N,j)=G%less(N,j) + dt*kb_half_trapz(KxG(0:),1,N-1)
+     !
+     G%less(N,j)=G%less(N,j)/(1.d0-0.5d0*dt*K%ret(N,N))
+  end do
+  !
+  ! G^<(t_{i},t_{N}) <= Hermite conjugate
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  ! if (.not.G%anomalous) then
+  do i=1,N-1
+     G%less(i,N) = -conjg(G%less(N,i))
+  end do
+  ! else
+  !    do i=1,N-1
+  !       G%less(i,N) = G%less(N,i)+G%ret(N,i)
+  !    end do
+  ! endif
+  !
+  ! G^{<}(t_{n},t_{n}) <= Diagonal
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  G%less(N,N)=Q%less(N,N)
+  !
+  KxG(0:)=zero
+  do s=0,L
+     KxG(s)=K%lmix(N,s)*get_rmix(G,s,N,L)
+  end do
+  G%less(N,N)=G%less(N,N)-xi*dtau*kb_trapz(KxG(0:),0,L)
+  !
+  KxG(0:)=zero
+  do s=1,N
+     KxG(s)=K%less(N,s)*get_adv(G,s,N)
+  end do
+  G%less(N,N)=G%less(N,N)+dt*kb_trapz(KxG(0:),1,N)
+  !
+  KxG(0:)=zero
+  do s=1,N-1
+     KxG(s)=K%ret(N,s)*G%less(s,N)
+  end do
+  G%less(N,N)=G%less(N,N) + dt*kb_half_trapz(KxG(0:),1,N-1)
+  !
+  G%less(N,N)=G%less(N,N)/(1.d0-0.5d0*dt*K%ret(N,N))
+  !
+  deallocate(KxG)
+end subroutine vie_kb_contour_gf_q
+
+
+
+
+
+!Q=Q(t,t'); K=contour_sigma
+subroutine vie_kb_contour_gf_sigma(Q,Self,G,params)
+  type(kb_contour_gf),intent(in)      :: Q
+  type(kb_contour_sigma),intent(in)   :: Self
+  type(kb_contour_gf),intent(inout)   :: G
+  type(kb_contour_params),intent(in)  :: params
+  type(kb_contour_gf)                 :: K
+  integer                             :: N,L
+  real(8)                             :: dt,dtau
+  integer                             :: i,j,s,itau,jtau
+  complex(8),dimension(:),allocatable :: KxG
+  !
+  N   = params%Nt                 !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  dt  = params%dt
+  dtau= params%dtau
+  !
+  allocate(KxG(0:max(N,L)))
+  call allocate_kb_contour_gf(K,params)
+  K = Self%reg
+  !
+  ! Ret component
+  ! G^R(t,t') - \int_{t'}^t K^R(t,s)*G^R(s,t')ds = Q^R(t,t')
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  G%ret(N,N)=Q%ret(N,N)
+  do j=1,N-1
+     G%ret(N,j)=Q%ret(N,j)
+     KxG(0:)=zero
+     do s=j,N-1
+        KxG(s)=K%ret(N,s)*G%ret(s,j)
+     eNd do
+     G%ret(N,j)=G%ret(N,j) + dt*kb_half_trapz(KxG(0:),j,N-1)
+     G%ret(N,j)=G%ret(N,j)/(1.d0-0.5d0*dt*K%ret(N,N))
+  end do
+  !
+  ! Lmix component
+  ! G^\lmix(t,tau') - \int_0^t K^R(t,s)*G^\lmix(s,tau')ds
+  !    = Q^\lmix(t,tau') + \int_0^\beta K^\lmix(t,s)*G^M(s,tau')ds
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  do jtau=0,L
+     G%lmix(N,jtau)=Q%lmix(N,jtau)
+     !
+     KxG(0:)=zero
+     do s=0,jtau
+        KxG(s)=K%lmix(N,s)*G%mats(s+L-jtau)
+     end do
+     G%lmix(N,jtau)=G%lmix(N,jtau)-dtau*kb_trapz(KxG(0:),0,jtau)
+     KxG(0:)=zero
+     do s=jtau,L
+        KxG(s)=K%lmix(N,s)*G%mats(s-jtau)
+     end do
+     G%lmix(N,jtau)=G%lmix(N,jtau)+dtau*kb_trapz(KxG(0:),jtau,L)
+     !
+     KxG(0:)=zero
+     do s=1,N-1
+        KxG(s)=K%ret(N,s)*G%lmix(s,jtau)
+     end do
+     G%lmix(N,jtau)=G%lmix(N,jtau) + dt*kb_half_trapz(KxG(0:),1,N-1)
+     !
+     G%lmix(N,jtau)=G%lmix(N,jtau)/(1.d0-0.5d0*dt*K%ret(N,N))
+  end do
+  !
+  ! Less component
+  ! G^<(t,t') - \int_0^t K^{R}(t,s)*G^{<}(s,t')ds
+  !    = Q^<(t,t') - i\int_0^\beta K^\lmix(t,s)*G^\rmix(s,t')ds
+  !      + \int_0^{t'} K^<(t,s)*G^A(s,t')ds
+  ! G^<(t_{N},t_{j})
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  do j=1, N-1
+     G%less(N,j)=Q%less(N,j)
+     !
+     KxG(0:)=zero
+     do s=0,L
+        KxG(s)=K%lmix(N,s)*get_rmix(G,s,j,L)
+     enddo
+     G%less(N,j)=G%less(N,j)-xi*dtau*kb_trapz(KxG(0:),0,L)
+     !
+     KxG(0:)=zero
+     do s=1,j
+        KxG(s)=K%less(N,s)*get_adv(G,s,j)
+     enddo
+     G%less(N,j)=G%less(N,j)+dt*kb_trapz(KxG(0:),1,j)
+     !
+     KxG(0:)=zero
+     do s=1,N-1
+        KxG(s)=K%ret(N,s)*G%less(s,j)
+     enddo
+     G%less(N,j)=G%less(N,j) + dt*kb_half_trapz(KxG(0:),1,N-1)
+     !
+     G%less(N,j)=G%less(N,j)/(1.d0-0.5d0*dt*K%ret(N,N))
+  end do
+  !
+  ! G^<(t_{i},t_{N}) <= Hermite conjugate
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  ! if (.not.G%anomalous) then
+  do i=1,N-1
+     G%less(i,N) = -conjg(G%less(N,i))
+  end do
+  ! else
+  !    do i=1,N-1
+  !       G%less(i,N) = G%less(N,i)+G%ret(N,i)
+  !    end do
+  ! endif
+  !
+  ! G^{<}(t_{n},t_{n}) <= Diagonal
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  G%less(N,N)=Q%less(N,N)
+  !
+  KxG(0:)=zero
+  do s=0,L
+     KxG(s)=K%lmix(N,s)*get_rmix(G,s,N,L)
+  end do
+  G%less(N,N)=G%less(N,N)-xi*dtau*kb_trapz(KxG(0:),0,L)
+  !
+  KxG(0:)=zero
+  do s=1,N
+     KxG(s)=K%less(N,s)*get_adv(G,s,N)
+  end do
+  G%less(N,N)=G%less(N,N)+dt*kb_trapz(KxG(0:),1,N)
+  !
+  KxG(0:)=zero
+  do s=1,N-1
+     KxG(s)=K%ret(N,s)*G%less(s,N)
+  end do
+  G%less(N,N)=G%less(N,N) + dt*kb_half_trapz(KxG(0:),1,N-1)
+  !
+  G%less(N,N)=G%less(N,N)/(1.d0-0.5d0*dt*K%ret(N,N))
+  !
+  deallocate(KxG)
+  call deallocate_kb_contour_gf(K)
+end subroutine vie_kb_contour_gf_sigma
+
+
+
+
+!Q=delta;K=contour_gf
+subroutine vie_kb_contour_gf_delta(K,G,params)
+  type(kb_contour_gf),intent(in)      :: K
+  type(kb_contour_gf),intent(inout)   :: G
+  type(kb_contour_params),intent(in)  :: params
+  integer                             :: N,L
+  real(8)                             :: dt,dtau
+  integer                             :: i,j,s,itau,jtau
+  complex(8),dimension(:),allocatable :: KxG
+  !
+  N   = params%Nt                 !<== work with the ACTUAL size of the contour
+  L   = params%Ntau
+  dt  = params%dt
+  dtau= params%dtau
+  !
+  allocate(KxG(0:max(N,L)))
+  !
+  ! Ret component
+  ! G^R(t,t') - \int_{t'}^t K^R(t,s)*G^R(s,t')ds = Q^R(t,t')
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  G%ret(N,N)=one                !Q%ret(N,N)
+  do j=1,N-1
+     G%ret(N,j)=zero            !Q%ret(N,j)
+     !
+     KxG(0:)=zero
+     do s=j,N-1
+        KxG(s)=K%ret(N,s)*G%ret(s,j)
+     eNd do
+     G%ret(N,j)=G%ret(N,j) + dt*kb_half_trapz(KxG(0:),j,N-1)
+     !
+     G%ret(N,j)=G%ret(N,j)/(1.d0-0.5d0*dt*K%ret(N,N))
+  end do
+  !
+  ! Lmix component
+  ! G^\lmix(t,tau') - \int_0^t K^R(t,s)*G^\lmix(s,tau')ds
+  !    = Q^\lmix(t,tau') + \int_0^\beta K^\lmix(t,s)*G^M(s,tau')ds
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  do jtau=0,L
+     G%lmix(N,jtau)=zero        !Q%lmix(N,jtau)
+     !
+     KxG(0:)=zero
+     do s=0,jtau
+        KxG(s)=K%lmix(N,s)*G%mats(s+L-jtau)
+     end do
+     G%lmix(N,jtau)=G%lmix(N,jtau)-dtau*kb_trapz(KxG(0:),0,jtau)
+     !
+     KxG(0:)=zero
+     do s=jtau,L
+        KxG(s)=K%lmix(N,s)*G%mats(s-jtau)
+     end do
+     G%lmix(N,jtau)=G%lmix(N,jtau)+dtau*kb_trapz(KxG(0:),jtau,L)
+     !
+     KxG(0:)=zero
+     do s=1,N-1
+        KxG(s)=K%ret(N,s)*G%lmix(s,jtau)
+     end do
+     G%lmix(N,jtau)=G%lmix(N,jtau) + dt*kb_half_trapz(KxG(0:),1,N-1)
+     !
+     G%lmix(N,jtau)=G%lmix(N,jtau)/(1.d0-0.5d0*dt*K%ret(N,N))
+  end do
+  !
+  ! Less component
+  ! G^<(t,t') - \int_0^t K^{R}(t,s)*G^{<}(s,t')ds
+  !    = Q^<(t,t') - i\int_0^\beta K^\lmix(t,s)*G^\rmix(s,t')ds
+  !      + \int_0^{t'} K^<(t,s)*G^A(s,t')ds
+  ! G^<(t_{N},t_{j})
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  do j=1, N-1
+     G%less(N,j)=zero           !Q%less(N,j)
+     !
+     KxG(0:)=zero
+     do s=0,L
+        KxG(s)=K%lmix(N,s)*get_rmix(G,s,j,L)
+     enddo
+     G%less(N,j)=G%less(N,j)-xi*dtau*kb_trapz(KxG(0:),0,L)
+     !
+     KxG(0:)=zero
+     do s=1,j
+        KxG(s)=K%less(N,s)*get_adv(G,s,j)
+     enddo
+     G%less(N,j)=G%less(N,j)+dt*kb_trapz(KxG(0:),1,j)
+     !
+     KxG(0:)=zero
+     do s=1,N-1
+        KxG(s)=K%ret(N,s)*G%less(s,j)
+     enddo
+     G%less(N,j)=G%less(N,j) + dt*kb_half_trapz(KxG(0:),1,N-1)
+     !
+     G%less(N,j)=G%less(N,j)/(1.d0-0.5d0*dt*K%ret(N,N))
+  end do
+  !
+  ! G^<(t_{i},t_{N}) <= Hermite conjugate
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  ! if (.not.G%anomalous) then
+  do i=1,N-1
+     G%less(i,N) = -conjg(G%less(N,i))
+  end do
+  ! else
+  !    do i=1,N-1
+  !       G%less(i,N) = G%less(N,i)+G%ret(N,i)
+  !    end do
+  ! endif
+  !
+  ! G^{<}(t_{n},t_{n}) <= Diagonal
+  ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+  G%less(N,N)=zero              !Q%less(N,N)
+  !
+  KxG(0:)=zero
+  do s=0,L
+     KxG(s)=K%lmix(N,s)*get_rmix(G,s,N,L)
+  end do
+  G%less(N,N)=G%less(N,N)-xi*dtau*kb_trapz(KxG(0:),0,L)
+  !
+  KxG(0:)=zero
+  do s=1,N
+     KxG(s)=K%less(N,s)*get_adv(G,s,N)
+  end do
+  G%less(N,N)=G%less(N,N)+dt*kb_trapz(KxG(0:),1,N)
+  !
+  KxG(0:)=zero
+  do s=1,N-1
+     KxG(s)=K%ret(N,s)*G%less(s,N)
+  end do
+  G%less(N,N)=G%less(N,N) + dt*kb_half_trapz(KxG(0:),1,N-1)
+  !
+  G%less(N,N)=G%less(N,N)/(1.d0-0.5d0*dt*K%ret(N,N))
+  !
+  deallocate(KxG)
+end subroutine vie_kb_contour_gf_delta


### PR DESCRIPTION
    ---> THIS VERSION IS DERIVED FROM THE DEVEL_SUPERC BRANCH <----
Code updated with the latest (tested) updated from devel_superc. The main purpose
of those updates was to treat automatically the splitted Sigma = Sigma_HF + Sigma_Reg.

The parts of code related to the superc case have been removed here.
See below for more info.

Test for the Bethe DOS quench gives perfect results:
16:42:01 [:~ … /TEST_SPLIT_SIGMA_BRANCH/branch_devel_split_sigma_bethe_dos_quench] devel_split_Sigma+* diff observables.neqipt ../branch_master_bethe_dos_quench/observables.nipt
16:42:08 [:~ … /TEST_SPLIT_SIGMA_BRANCH/branch_devel_split_sigma_bethe_dos_quench] devel_split_Sigma+*

LOG:
    This version feature a big update and reshape of the code.
    The NEQ_CONTOUR_GF.f90 module, which is the core of the code, has been
    splitted in many different files, each containing dedicated procedures
    for a specific task, e.g. neq_contour_gf_convolute.f90 contains
    routines that performs various type of convolutions.

    In particular a kb_contour_sigma type has been introduced to contain
    self-energy functions, which includes regular, i.e. a normal kb_contour_gf
    type, plus a singular part, i.e. a term proprtional to a contour delta
    function (local in time).
    Quite all the routines have been extended to this new type, in particular
    the convolutions and vide/vie solution. In this way it was straightforward
    to automatically perform product of the form:
    C= (Sigma_HF.delta_C(t,t') + Sigma(t,t'))*B

    as well as more simple products

    C = A*B

    Similarly, the solution of vide/vie with a Self-energy kernel K is automated,
    so that the HF, singular part goes straight with the linear term of the form h*f,
    while the regular part actually define the kernel K in K*f.

    ------->     WARNING      <---------
    This approach requires to modify a bit the drivers to comply with the new standard.
    While this is a super easy step, it allows to extend the codes to more complicated
    situations, just like the away from half-filling case or different way to treat the
    HF, singular, term.

    Test for the BETHE-DOS case has been performed with 100% success.